### PR TITLE
Add _USE_MATH_DEFINES definition for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if (WIN32)
 endif()
 
 if (MSVC)
+    add_compile_definitions(_USE_MATH_DEFINES)
     add_compile_options("$<$<COMPILE_LANGUAGE:C>:/utf-8>")
     add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:/utf-8>")
     add_compile_options("$<$<COMPILE_LANGUAGE:C>:/bigobj>")


### PR DESCRIPTION
## Overview

Building the project on Windows via MSVC currently fails with: `error C2065: 'M_PI': undeclared identifier`.

Unlike POSIX-compliant compilers, MSVC hides math constants behind the `_USE_MATH_DEFINES` macro. This commit explicitly adds the definition to the CMake MSVC configuration block to ensure out-of-the-box compilation on Windows.

# Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: yes - used an AI assistant to format the pull request description and validate the CMake syntax.