### PR TITLE
CUDA: fix turbo cache types on multi-GPU (constant memory init)

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -8,15 +8,31 @@
 
 #include <atomic>
 
-// InnerQ: update the fattn-side inverse scale array from host
+// InnerQ: update the fattn-side inverse scale array from host (all devices)
 void turbo_innerq_update_fattn_scales(const float * scale_inv) {
-    cudaMemcpyToSymbol(d_innerq_channel_scale_inv_fattn, scale_inv, 128 * sizeof(float));
+    int cur_device;
+    cudaGetDevice(&cur_device);
+    int device_count;
+    cudaGetDeviceCount(&device_count);
+    for (int id = 0; id < device_count; id++) {
+        cudaSetDevice(id);
+        cudaMemcpyToSymbol(d_innerq_channel_scale_inv_fattn, scale_inv, 128 * sizeof(float));
+    }
+    cudaSetDevice(cur_device);
 }
 
 void turbo_innerq_init_fattn() {
     float ones[128];
     for (int i = 0; i < 128; i++) ones[i] = 1.0f;
-    cudaMemcpyToSymbol(d_innerq_channel_scale_inv_fattn, ones, sizeof(ones));
+    int cur_device;
+    cudaGetDevice(&cur_device);
+    int device_count;
+    cudaGetDeviceCount(&device_count);
+    for (int id = 0; id < device_count; id++) {
+        cudaSetDevice(id);
+        cudaMemcpyToSymbol(d_innerq_channel_scale_inv_fattn, ones, sizeof(ones));
+    }
+    cudaSetDevice(cur_device);
 }
 
 // Q² calibration: host-side management
@@ -28,9 +44,17 @@ void turbo_q_calibrate_init() {
 
     double zeros[128] = {};
     int zero = 0, one = 1;
-    cudaMemcpyToSymbol(d_q_channel_sq_fattn, zeros, sizeof(zeros));
-    cudaMemcpyToSymbol(d_q_channel_count_fattn, &zero, sizeof(zero));
-    cudaMemcpyToSymbol(d_q_calibrate_fattn, &one, sizeof(one));
+    int cur_device;
+    cudaGetDevice(&cur_device);
+    int device_count;
+    cudaGetDeviceCount(&device_count);
+    for (int id = 0; id < device_count; id++) {
+        cudaSetDevice(id);
+        cudaMemcpyToSymbol(d_q_channel_sq_fattn, zeros, sizeof(zeros));
+        cudaMemcpyToSymbol(d_q_channel_count_fattn, &zero, sizeof(zero));
+        cudaMemcpyToSymbol(d_q_calibrate_fattn, &one, sizeof(one));
+    }
+    cudaSetDevice(cur_device);
     q_calibrate_state = 1;
     fprintf(stderr, "TURBO_Q_CALIBRATE: collecting per-position Q² statistics\n");
 }
@@ -38,8 +62,17 @@ void turbo_q_calibrate_init() {
 void turbo_q_calibrate_finalize() {
     if (q_calibrate_state != 1) return;
 
+    int cur_device;
+    cudaGetDevice(&cur_device);
+    int device_count;
+    cudaGetDeviceCount(&device_count);
+
     int zero = 0;
-    cudaMemcpyToSymbol(d_q_calibrate_fattn, &zero, sizeof(zero));
+    for (int id = 0; id < device_count; id++) {
+        cudaSetDevice(id);
+        cudaMemcpyToSymbol(d_q_calibrate_fattn, &zero, sizeof(zero));
+    }
+    cudaSetDevice(cur_device);
 
     double sq[128];
     int count;

--- a/ggml/src/ggml-cuda/turbo-quant-cuda.cuh
+++ b/ggml/src/ggml-cuda/turbo-quant-cuda.cuh
@@ -41,13 +41,21 @@ static int     h_extract_max = 0;
 static int     h_extract_state = 0;  // 0=uninit, 1=collecting, 2=done
 
 static void turbo_extract_init(int max_samples) {
+	int cur_device;
+	cudaGetDevice(&cur_device);
+	int device_count;
+	cudaGetDeviceCount(&device_count);
 	cudaMalloc(&h_extract_gpu_buf, (size_t)max_samples * sizeof(float));
 	cudaMalloc(&h_extract_gpu_pos, sizeof(int));
 	int zero = 0;
 	cudaMemcpy(h_extract_gpu_pos, &zero, sizeof(int), cudaMemcpyHostToDevice);
-	cudaMemcpyToSymbol(d_extract_buf_ptr, &h_extract_gpu_buf, sizeof(float *));
-	cudaMemcpyToSymbol(d_extract_pos_ptr, &h_extract_gpu_pos, sizeof(int *));
-	cudaMemcpyToSymbol(d_extract_max_val, &max_samples, sizeof(int));
+	for (int id = 0; id < device_count; id++) {
+		cudaSetDevice(id);
+		cudaMemcpyToSymbol(d_extract_buf_ptr, &h_extract_gpu_buf, sizeof(float *));
+		cudaMemcpyToSymbol(d_extract_pos_ptr, &h_extract_gpu_pos, sizeof(int *));
+		cudaMemcpyToSymbol(d_extract_max_val, &max_samples, sizeof(int));
+	}
+	cudaSetDevice(cur_device);
 	h_extract_max = max_samples;
 	h_extract_state = 1;
 	fprintf(stderr, "TURBO_EXTRACT: collecting up to %d post-rotation samples\n", max_samples);
@@ -71,13 +79,21 @@ static void turbo_extract_check_done() {
 				pos, path, (float)pos * sizeof(float) / (1024*1024));
 	}
 	free(host_buf);
-	// Disable extraction (set device pointers to null)
+	// Disable extraction (set device pointers to null) on all devices
 	float * null_ptr = nullptr;
 	int   * null_iptr = nullptr;
 	int     zero_max = 0;
-	cudaMemcpyToSymbol(d_extract_buf_ptr, &null_ptr, sizeof(float *));
-	cudaMemcpyToSymbol(d_extract_pos_ptr, &null_iptr, sizeof(int *));
-	cudaMemcpyToSymbol(d_extract_max_val, &zero_max, sizeof(int));
+	int cur_dev;
+	cudaGetDevice(&cur_dev);
+	int dev_count;
+	cudaGetDeviceCount(&dev_count);
+	for (int id = 0; id < dev_count; id++) {
+		cudaSetDevice(id);
+		cudaMemcpyToSymbol(d_extract_buf_ptr, &null_ptr, sizeof(float *));
+		cudaMemcpyToSymbol(d_extract_pos_ptr, &null_iptr, sizeof(int *));
+		cudaMemcpyToSymbol(d_extract_max_val, &zero_max, sizeof(int));
+	}
+	cudaSetDevice(cur_dev);
 	cudaFree(h_extract_gpu_buf); h_extract_gpu_buf = nullptr;
 	cudaFree(h_extract_gpu_pos); h_extract_gpu_pos = nullptr;
 	h_extract_state = 2;
@@ -94,19 +110,27 @@ static __device__ void turbo_extract_append(const float * x) {
 	}
 }
 
-// Host-side init: set identity scales, zero accumulators
+// Host-side init: set identity scales, zero accumulators (all devices)
 static void turbo_innerq_init() {
     float ones[128];
     for (int i = 0; i < 128; i++) ones[i] = 1.0f;
     float zeros[128] = {};
     int zero = 0;
-    cudaMemcpyToSymbol(d_innerq_channel_scale, ones, sizeof(ones));
-    cudaMemcpyToSymbol(d_innerq_channel_scale_inv, ones, sizeof(ones));
-    cudaMemcpyToSymbol(d_innerq_channel_sq, zeros, sizeof(zeros));
-    cudaMemcpyToSymbol(d_innerq_channel_max, zeros, sizeof(zeros));
-    cudaMemcpyToSymbol(d_innerq_count, &zero, sizeof(zero));
-    cudaMemcpyToSymbol(d_innerq_calibrate, &zero, sizeof(zero));
-    cudaMemcpyToSymbol(d_innerq_is_k, &zero, sizeof(zero));
+    int cur_device;
+    cudaGetDevice(&cur_device);
+    int device_count;
+    cudaGetDeviceCount(&device_count);
+    for (int id = 0; id < device_count; id++) {
+        cudaSetDevice(id);
+        cudaMemcpyToSymbol(d_innerq_channel_scale, ones, sizeof(ones));
+        cudaMemcpyToSymbol(d_innerq_channel_scale_inv, ones, sizeof(ones));
+        cudaMemcpyToSymbol(d_innerq_channel_sq, zeros, sizeof(zeros));
+        cudaMemcpyToSymbol(d_innerq_channel_max, zeros, sizeof(zeros));
+        cudaMemcpyToSymbol(d_innerq_count, &zero, sizeof(zero));
+        cudaMemcpyToSymbol(d_innerq_calibrate, &zero, sizeof(zero));
+        cudaMemcpyToSymbol(d_innerq_is_k, &zero, sizeof(zero));
+    }
+    cudaSetDevice(cur_device);
     turbo_innerq_init_fattn();
     turbo_q_calibrate_init();
 }
@@ -116,20 +140,37 @@ static void turbo_innerq_set_is_k(int is_k) {
     cudaMemcpyToSymbol(d_innerq_is_k, &is_k, sizeof(int));
 }
 
-// Host-side: enable calibration mode
+// Host-side: enable calibration mode (all devices)
 static void turbo_innerq_start_calibration() {
     float zeros[128] = {};
     int zero = 0, one = 1;
-    cudaMemcpyToSymbol(d_innerq_channel_sq, zeros, sizeof(zeros));
-    cudaMemcpyToSymbol(d_innerq_channel_max, zeros, sizeof(zeros));
-    cudaMemcpyToSymbol(d_innerq_count, &zero, sizeof(zero));
-    cudaMemcpyToSymbol(d_innerq_calibrate, &one, sizeof(one));
+    int cur_device;
+    cudaGetDevice(&cur_device);
+    int device_count;
+    cudaGetDeviceCount(&device_count);
+    for (int id = 0; id < device_count; id++) {
+        cudaSetDevice(id);
+        cudaMemcpyToSymbol(d_innerq_channel_sq, zeros, sizeof(zeros));
+        cudaMemcpyToSymbol(d_innerq_channel_max, zeros, sizeof(zeros));
+        cudaMemcpyToSymbol(d_innerq_count, &zero, sizeof(zero));
+        cudaMemcpyToSymbol(d_innerq_calibrate, &one, sizeof(one));
+    }
+    cudaSetDevice(cur_device);
 }
 
 // Host-side: finalize calibration — compute scales from accumulated stats
 static void turbo_innerq_finalize_calibration() {
+    int cur_device;
+    cudaGetDevice(&cur_device);
+    int device_count;
+    cudaGetDeviceCount(&device_count);
+
     int zero = 0;
-    cudaMemcpyToSymbol(d_innerq_calibrate, &zero, sizeof(zero));
+    for (int id = 0; id < device_count; id++) {
+        cudaSetDevice(id);
+        cudaMemcpyToSymbol(d_innerq_calibrate, &zero, sizeof(zero));
+    }
+    cudaSetDevice(cur_device);
 
     float sq[128], ch_max[128];
     int count;
@@ -210,8 +251,12 @@ static void turbo_innerq_finalize_calibration() {
         fprintf(stderr, "InnerQ: max ratio %.3f < 1.2 — channels already balanced, disabling (would hurt quality)\n", max_ratio);
         float ones[128];
         for (int i = 0; i < 128; i++) ones[i] = 1.0f;
-        cudaMemcpyToSymbol(d_innerq_channel_scale, ones, sizeof(ones));
-        cudaMemcpyToSymbol(d_innerq_channel_scale_inv, ones, sizeof(ones));
+        for (int id = 0; id < device_count; id++) {
+            cudaSetDevice(id);
+            cudaMemcpyToSymbol(d_innerq_channel_scale, ones, sizeof(ones));
+            cudaMemcpyToSymbol(d_innerq_channel_scale_inv, ones, sizeof(ones));
+        }
+        cudaSetDevice(cur_device);
         turbo_innerq_update_fattn_scales(ones);
         return;
     }
@@ -232,8 +277,12 @@ static void turbo_innerq_finalize_calibration() {
         }
     }
 
-    cudaMemcpyToSymbol(d_innerq_channel_scale, scale, sizeof(scale));
-    cudaMemcpyToSymbol(d_innerq_channel_scale_inv, scale_inv, sizeof(scale_inv));
+    for (int id = 0; id < device_count; id++) {
+        cudaSetDevice(id);
+        cudaMemcpyToSymbol(d_innerq_channel_scale, scale, sizeof(scale));
+        cudaMemcpyToSymbol(d_innerq_channel_scale_inv, scale_inv, sizeof(scale_inv));
+    }
+    cudaSetDevice(cur_device);
     turbo_innerq_update_fattn_scales(scale_inv);
 }
 


### PR DESCRIPTION
## Summary

Turbo KV cache types (turbo2, turbo3, turbo4, turbo TCQ) produce garbage output or crash with illegal memory access when using `--tensor-split` across multiple GPUs.

The root cause is that all turbo initialization functions use `cudaMemcpyToSymbol()` to write runtime values into CUDA `__device__` constant memory (InnerQ channel scales, calibration accumulators, Q² statistics, extraction buffers). In CUDA, `__device__` symbols are **per-device** — each GPU has its own copy. The existing code writes to whichever GPU happens to be active, leaving the other GPU(s) with uninitialized constant memory (zeros). When layers assigned to the uninitialized GPU run turbo dequant kernels, they read garbage from constant memory.

Standard cache types like `q8_0` are unaffected because they use compile-time `__constant__` initializers or read from global memory.

## Changes

Two files, same pattern throughout — save/restore the active device and loop over all GPUs:

**`ggml/src/ggml-cuda/turbo-quant-cuda.cuh`** (4 functions):
- `turbo_innerq_init()` — identity scale initialization
- `turbo_innerq_start_calibration()` — calibration accumulator reset
- `turbo_innerq_finalize_calibration()` — scale writes (3 call sites)
- `turbo_extract_init()` / `turbo_extract_check_done()` — extraction buffer pointers

**`ggml/src/ggml-cuda/fattn.cu`** (4 functions):
- `turbo_innerq_init_fattn()` — fattn-side inverse scales
- `turbo_innerq_update_fattn_scales()` — fattn-side scale updates
- `turbo_q_calibrate_init()` — Q² calibration state
- `turbo_q_calibrate_finalize()` — calibration disable flag

## Testing

Tested on dual GPU setup (RTX 3090 Ti + RTX 3090) with:
- `--tensor-split 0.5,0.5 --split-mode layer`
- `--cache-type-k turbo4 --cache-type-v turbo4`
- Model: gemma-4-31B-it (UD-Q5_K_XL)

Before fix: garbage output. After fix: correct output.

## Related issues

- Fixes #17 — "CUDA error: an illegal memory access was encountered - when using second GPU"
- Relates to #12 — garbage output on multi-GPU setups with turbo cache types