### PR TITLE
ROCm 7.2 / RDNA3 build support + gated_delta_net perf fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ At 3.25 bits per value, TCQ produces **lower perplexity than FP16** KV cache (5.
 
 ## Build
 
+### NVIDIA (CUDA)
+
 ```sh
 cmake -B build \
   -DGGML_CUDA=ON \
@@ -26,6 +28,24 @@ cmake -B build \
 
 cmake --build build -j$(nproc)
 ```
+
+### AMD (ROCm / HIP)
+
+Tested on ROCm 7.2 + RDNA3 (`gfx1100`, RX 7900 XTX). Other RDNA3/RDNA4 targets should work by swapping `AMDGPU_TARGETS`.
+
+```sh
+cmake -B build \
+  -DGGML_HIP=ON \
+  -DAMDGPU_TARGETS=gfx1100 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLAMA_BUILD_SERVER=ON \
+  -DCMAKE_C_COMPILER=/opt/rocm/bin/amdclang \
+  -DCMAKE_CXX_COMPILER=/opt/rocm/bin/amdclang++
+
+cmake --build build -j$(nproc)
+```
+
+Measured on RX 7900 XTX with Qwen*-27B Q4_K_M targets and the DFlash draft: AR ~27 tok/s, DFlash ~51 tok/s on Qwen3.5 (×1.88), ~43 tok/s on Qwen3.6 (×1.61). Build also produces a working `llama-server` with `--spec-type dflash`.
 
 ## Recommended configurations
 

--- a/ggml/src/ggml-cuda/argmax.cu
+++ b/ggml/src/ggml-cuda/argmax.cu
@@ -80,8 +80,8 @@ static __global__ void argmax_f32(
     // Warp reduction for argmax
 #pragma unroll
     for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
-        const float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
-        const int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
+        const float val = __shfl_xor_sync(0xFFFFFFFFULL, maxval, offset, WARP_SIZE);
+        const int   col = __shfl_xor_sync(0xFFFFFFFFULL, argmax, offset, WARP_SIZE);
         if (val > maxval) {
             maxval = val;
             argmax = col;
@@ -92,8 +92,8 @@ static __global__ void argmax_f32(
     if (output_logprob) {
 #pragma unroll
         for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
-            float other_max = __shfl_xor_sync(0xFFFFFFFF, logit_max, offset, WARP_SIZE);
-            float other_sum = __shfl_xor_sync(0xFFFFFFFF, sum_exp, offset, WARP_SIZE);
+            float other_max = __shfl_xor_sync(0xFFFFFFFFULL, logit_max, offset, WARP_SIZE);
+            float other_sum = __shfl_xor_sync(0xFFFFFFFFULL, sum_exp, offset, WARP_SIZE);
             if (other_max > logit_max) {
                 sum_exp = sum_exp * expf(logit_max - other_max) + other_sum;
                 logit_max = other_max;
@@ -142,16 +142,16 @@ static __global__ void argmax_f32(
 
 #pragma unroll
             for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
-                float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
-                int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
+                float val = __shfl_xor_sync(0xFFFFFFFFULL, maxval, offset, WARP_SIZE);
+                int   col = __shfl_xor_sync(0xFFFFFFFFULL, argmax, offset, WARP_SIZE);
                 if (val > maxval) {
                     maxval = val;
                     argmax = col;
                 }
 
                 if (output_logprob) {
-                    float other_max = __shfl_xor_sync(0xFFFFFFFF, logit_max, offset, WARP_SIZE);
-                    float other_sum = __shfl_xor_sync(0xFFFFFFFF, sum_exp, offset, WARP_SIZE);
+                    float other_max = __shfl_xor_sync(0xFFFFFFFFULL, logit_max, offset, WARP_SIZE);
+                    float other_sum = __shfl_xor_sync(0xFFFFFFFFULL, sum_exp, offset, WARP_SIZE);
                     if (other_max > logit_max) {
                         sum_exp = sum_exp * expf(logit_max - other_max) + other_sum;
                         logit_max = other_max;
@@ -262,8 +262,8 @@ static __global__ void topk_f32(
     // Each step: lane gets partner's min element, if it beats our min, replace and re-heapify
     for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
         for (int i = 0; i < K; i++) {
-            float partner_val = __shfl_xor_sync(0xFFFFFFFF, heap_val[i], offset);
-            int partner_idx = __shfl_xor_sync(0xFFFFFFFF, heap_idx[i], offset);
+            float partner_val = __shfl_xor_sync(0xFFFFFFFFULL, heap_val[i], offset);
+            int partner_idx = __shfl_xor_sync(0xFFFFFFFFULL, heap_idx[i], offset);
             if (partner_val > heap_val[0]) {
                 heap_val[0] = partner_val;
                 heap_idx[0] = partner_idx;
@@ -343,8 +343,8 @@ static __global__ void topk_f32(
         // Single warp: reduce softmax within warp
         if (output_logprob) {
             for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
-                float other_max = __shfl_xor_sync(0xFFFFFFFF, logit_max, offset, WARP_SIZE);
-                float other_sum = __shfl_xor_sync(0xFFFFFFFF, sum_exp, offset, WARP_SIZE);
+                float other_max = __shfl_xor_sync(0xFFFFFFFFULL, logit_max, offset, WARP_SIZE);
+                float other_sum = __shfl_xor_sync(0xFFFFFFFFULL, sum_exp, offset, WARP_SIZE);
                 if (other_max > logit_max) {
                     sum_exp = sum_exp * expf(logit_max - other_max) + other_sum;
                     logit_max = other_max;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -405,11 +405,11 @@ struct ggml_cuda_unroll<1> {
 template<int width = WARP_SIZE>
 static __device__ __forceinline__ int warp_reduce_sum(int x) {
 #if !defined(GGML_USE_HIP) && __CUDA_ARCH__ >= GGML_CUDA_CC_AMPERE
-    return __reduce_add_sync(0xffffffff, x);
+    return __reduce_add_sync(0xFFFFFFFFULL, x);
 #else
 #pragma unroll
     for (int offset = width/2; offset > 0; offset >>= 1) {
-        x += __shfl_xor_sync(0xffffffff, x, offset, width);
+        x += __shfl_xor_sync(0xFFFFFFFFULL, x, offset, width);
     }
     return x;
 #endif // !defined(GGML_USE_HIP) && __CUDA_ARCH__ >= GGML_CUDA_CC_AMPERE
@@ -419,7 +419,7 @@ template<int width = WARP_SIZE>
 static __device__ __forceinline__ float warp_reduce_sum(float x) {
 #pragma unroll
     for (int offset = width/2; offset > 0; offset >>= 1) {
-        x += __shfl_xor_sync(0xffffffff, x, offset, width);
+        x += __shfl_xor_sync(0xFFFFFFFFULL, x, offset, width);
     }
     return x;
 }
@@ -428,8 +428,8 @@ template<int width = WARP_SIZE>
 static __device__ __forceinline__ float2 warp_reduce_sum(float2 a) {
 #pragma unroll
     for (int offset = width/2; offset > 0; offset >>= 1) {
-        a.x += __shfl_xor_sync(0xffffffff, a.x, offset, width);
-        a.y += __shfl_xor_sync(0xffffffff, a.y, offset, width);
+        a.x += __shfl_xor_sync(0xFFFFFFFFULL, a.x, offset, width);
+        a.y += __shfl_xor_sync(0xFFFFFFFFULL, a.y, offset, width);
     }
     return a;
 }
@@ -439,7 +439,7 @@ static __device__ __forceinline__ half2 warp_reduce_sum(half2 a) {
 #ifdef FP16_AVAILABLE
 #pragma unroll
     for (int offset = width/2; offset > 0; offset >>= 1) {
-        a = __hadd2(a, __shfl_xor_sync(0xffffffff, a, offset, width));
+        a = __hadd2(a, __shfl_xor_sync(0xFFFFFFFFULL, a, offset, width));
     }
     return a;
 
@@ -452,11 +452,11 @@ static __device__ __forceinline__ half2 warp_reduce_sum(half2 a) {
 template<int width = WARP_SIZE>
 static __device__ __forceinline__ int warp_reduce_all(int x) {
     if (width == ggml_cuda_get_physical_warp_size()) {
-        return __all_sync(0xffffffff, x);
+        return __all_sync(0xFFFFFFFFULL, x);
     } else {
 #pragma unroll
         for (int offset = width/2; offset > 0; offset >>= 1) {
-            x = __shfl_xor_sync(0xffffffff, x, offset, width) && x;
+            x = __shfl_xor_sync(0xFFFFFFFFULL, x, offset, width) && x;
         }
         return x;
     }
@@ -465,11 +465,11 @@ static __device__ __forceinline__ int warp_reduce_all(int x) {
 template<int width = WARP_SIZE>
 static __device__ __forceinline__ int warp_reduce_any(int x) {
     if (width == ggml_cuda_get_physical_warp_size()) {
-        return __any_sync(0xffffffff, x);
+        return __any_sync(0xFFFFFFFFULL, x);
     } else {
 #pragma unroll
         for (int offset = width/2; offset > 0; offset >>= 1) {
-            x = __shfl_xor_sync(0xffffffff, x, offset, width) || x;
+            x = __shfl_xor_sync(0xFFFFFFFFULL, x, offset, width) || x;
         }
         return x;
     }
@@ -479,7 +479,7 @@ template<int width = WARP_SIZE>
 static __device__ __forceinline__ float warp_reduce_max(float x) {
 #pragma unroll
     for (int offset = width/2; offset > 0; offset >>= 1) {
-        x = fmaxf(x, __shfl_xor_sync(0xffffffff, x, offset, width));
+        x = fmaxf(x, __shfl_xor_sync(0xFFFFFFFFULL, x, offset, width));
     }
     return x;
 }
@@ -489,7 +489,7 @@ static __device__ __forceinline__ T warp_prefix_inclusive_sum(T x) {
     const int lane_id = threadIdx.x % width;
 #pragma unroll
     for (int offset = 1; offset < width; offset <<= 1) {
-        const T t = __shfl_up_sync(0xffffffff, x, offset, width);
+        const T t = __shfl_up_sync(0xFFFFFFFFULL, x, offset, width);
         if (lane_id >= offset) {
             x += t;
         }
@@ -502,8 +502,8 @@ static __device__ __forceinline__ float2 warp_prefix_inclusive_sum(float2 a) {
     const int lane_id = threadIdx.x % width;
 #pragma unroll
     for (int offset = 1; offset < width; offset <<= 1) {
-        const float t_x = __shfl_up_sync(0xffffffff, a.x, offset, width);
-        const float t_y = __shfl_up_sync(0xffffffff, a.y, offset, width);
+        const float t_x = __shfl_up_sync(0xFFFFFFFFULL, a.x, offset, width);
+        const float t_y = __shfl_up_sync(0xFFFFFFFFULL, a.y, offset, width);
         if (lane_id >= offset) {
             a.x += t_x;
             a.y += t_y;
@@ -518,7 +518,7 @@ static __device__ __forceinline__ half2 warp_prefix_inclusive_sum(half2 a) {
     const int lane_id = threadIdx.x % width;
 #pragma unroll
     for (int offset = 1; offset < width; offset <<= 1) {
-        const half2 t = __shfl_up_sync(0xffffffff, a, offset, width);
+        const half2 t = __shfl_up_sync(0xFFFFFFFFULL, a, offset, width);
         if (lane_id >= offset) {
             a = __hadd2(a, t);
         }
@@ -645,7 +645,7 @@ static __device__ __forceinline__ half2 warp_reduce_max(half2 x) {
 #if !defined(GGML_USE_HIP) && __CUDA_ARCH__ >= GGML_CUDA_CC_PASCAL || defined(GGML_USE_HIP)
 #pragma unroll
    for (int offset = width/2; offset > 0; offset >>= 1) {
-       x = ggml_cuda_hmax2(x, __shfl_xor_sync(0xffffffff, x, offset, width));
+       x = ggml_cuda_hmax2(x, __shfl_xor_sync(0xFFFFFFFFULL, x, offset, width));
    }
    return x;
 #else

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -709,8 +709,8 @@ static __device__ __forceinline__ void quantize_q8_1_to_shared(
     }
 #pragma unroll
     for (int mask = QI8_1/2; mask > 0; mask >>= 1) {
-        amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, mask, 32));
-        sum +=             __shfl_xor_sync(0xFFFFFFFF, sum,  mask, 32);
+        amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFFULL, amax, mask, 32));
+        sum +=             __shfl_xor_sync(0xFFFFFFFFULL, sum,  mask, 32);
     }
 
     const float d = amax / 127;

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -666,7 +666,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
         for (int col = 0; col < cols_per_thread; ++col) {
 #pragma unroll
             for (int offset = 16; offset >= 4; offset >>= 1) {
-                KQ_max_new[col] = fmaxf(KQ_max_new[col], __shfl_xor_sync(0xFFFFFFFF, KQ_max_new[col], offset, warp_size));
+                KQ_max_new[col] = fmaxf(KQ_max_new[col], __shfl_xor_sync(0xFFFFFFFFULL, KQ_max_new[col], offset, warp_size));
             }
         }
 
@@ -746,7 +746,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_iter(
 #endif // defined(TURING_MMA_AVAILABLE)
 #pragma unroll
             for (int offset = offset_first; offset >= offset_last; offset >>= 1) {
-                KQ_max_new[col] = fmaxf(KQ_max_new[col], __shfl_xor_sync(0xFFFFFFFF, KQ_max_new[col], offset, warp_size));
+                KQ_max_new[col] = fmaxf(KQ_max_new[col], __shfl_xor_sync(0xFFFFFFFFULL, KQ_max_new[col], offset, warp_size));
             }
         }
 
@@ -1228,7 +1228,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
         for (int col = 0; col < cols_per_thread; ++col) {
 #pragma unroll
             for (int offset = offset_first; offset >= offset_last; offset >>= 1) {
-                KQ_rowsum[col] += __shfl_xor_sync(0xFFFFFFFF, KQ_rowsum[col], offset, warp_size);
+                KQ_rowsum[col] += __shfl_xor_sync(0xFFFFFFFFULL, KQ_rowsum[col], offset, warp_size);
             }
         }
     }
@@ -1389,7 +1389,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
 #pragma unroll
         for (int offset = np*cols_per_warp/2; offset >= cols_per_warp; offset >>= 1) {
             if (offset < warp_size) {
-                KQ_cmn = fmaxf(KQ_cmn, __shfl_xor_sync(0xFFFFFFFF, KQ_cmn, offset, warp_size));
+                KQ_cmn = fmaxf(KQ_cmn, __shfl_xor_sync(0xFFFFFFFFULL, KQ_cmn, offset, warp_size));
             }
         }
 
@@ -1407,7 +1407,7 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
 #pragma unroll
         for (int offset = np*cols_per_warp/2; offset >= cols_per_warp; offset >>= 1) {
             if (offset < warp_size) {
-                KQ_crs += __shfl_xor_sync(0xFFFFFFFF, KQ_crs, offset, warp_size);
+                KQ_crs += __shfl_xor_sync(0xFFFFFFFFULL, KQ_crs, offset, warp_size);
             }
         }
 

--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -319,7 +319,7 @@ static __global__ void flash_attn_ext_vec(
         for (int j = 0; j < ncols; ++j) {
 #pragma unroll
             for (int offset = nthreads_KQ; offset < WARP_SIZE; offset <<= 1) {
-                KQ_max_new[j] = fmaxf(KQ_max_new[j], __shfl_xor_sync(0xFFFFFFFF, KQ_max_new[j], offset, WARP_SIZE));
+                KQ_max_new[j] = fmaxf(KQ_max_new[j], __shfl_xor_sync(0xFFFFFFFFULL, KQ_max_new[j], offset, WARP_SIZE));
             }
             const float KQ_max_scale = expf(KQ_max[j] - KQ_max_new[j]);
             KQ_max[j] = KQ_max_new[j];

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -509,7 +509,7 @@ static __device__ __forceinline__ float fwht128_butterfly_inplace(float val, flo
     // Intra-warp passes: shuffle xor with stride h, no smem, no sync.
     #pragma unroll
     for (int h = 1; h <= 16; h *= 2) {
-        const float other = __shfl_xor_sync(0xFFFFFFFF, val, h);
+        const float other = __shfl_xor_sync(0xFFFFFFFFULL, val, h);
         val = (tid & h) ? (other - val) : (val + other);
     }
 
@@ -533,7 +533,7 @@ static __device__ __forceinline__ float fwht128_butterfly_inplace(float val, flo
 static __device__ __forceinline__ void fwht128_store_half(
         float val, half * dst_base) {
     const int tid = threadIdx.x;
-    const float neighbor = __shfl_xor_sync(0xFFFFFFFF, val, 1);
+    const float neighbor = __shfl_xor_sync(0xFFFFFFFFULL, val, 1);
     if ((tid & 1) == 0) {
         const half2 packed = __floats2half2_rn(val, neighbor);
         *((half2 *)(dst_base + tid)) = packed;

--- a/ggml/src/ggml-cuda/gated_delta_net.cu
+++ b/ggml/src/ggml-cuda/gated_delta_net.cu
@@ -1,7 +1,17 @@
 #include "gated_delta_net.cuh"
 
+// RDNA3 wants 1 block/SM here: with 2 blocks/SM the compiler is forced under
+// ~128 VGPR/lane and spills on this kernel. 1 block/SM raises the per-lane
+// VGPR budget to ~256 and eliminates the spill entirely. CUDA keeps 2.
+// See llama.cpp issue #20354 (GATED_DELTA_NET HIP underperforms on RDNA3).
+#if defined(GGML_USE_HIP)
+#define GGML_GDN_MIN_BLOCKS_PER_SM 1
+#else
+#define GGML_GDN_MIN_BLOCKS_PER_SM 2
+#endif
+
 template <int S_v, bool KDA>
-__global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, 2)
+__global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, GGML_GDN_MIN_BLOCKS_PER_SM)
 gated_delta_net_cuda(const float * q,
                                      const float * k,
                                      const float * v,
@@ -279,7 +289,7 @@ void ggml_cuda_op_gated_delta_net(ggml_backend_cuda_context & ctx, ggml_tensor *
 #define GDN_TREE_ROOT_PARENT (-1)
 
 template <int S_v, bool KDA>
-__global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, 2)
+__global__ void __launch_bounds__((ggml_cuda_get_physical_warp_size() < S_v ? ggml_cuda_get_physical_warp_size() : S_v) * 4, GGML_GDN_MIN_BLOCKS_PER_SM)
 gated_delta_net_tree_cuda(const float * q,
                           const float * k,
                           const float * v,

--- a/ggml/src/ggml-cuda/mma.cuh
+++ b/ggml/src/ggml-cuda/mma.cuh
@@ -52,8 +52,8 @@ static __device__ __forceinline__ int ggml_cuda_movmatrix(const int x) {
     const int shift_low  = ((src_j + 0) % 2) * 16;
     const int shift_high = ((src_j + 1) % 2) * 16;
 
-    const int ret_low  = (__shfl_sync(0xFFFFFFFF, x, src_laneid_low,  WARP_SIZE) >> shift_low)  & 0x0000FFFF;
-    const int ret_high = (__shfl_sync(0xFFFFFFFF, x, src_laneid_high, WARP_SIZE) << shift_high) & 0xFFFF0000;
+    const int ret_low  = (__shfl_sync(0xFFFFFFFFULL, x, src_laneid_low,  WARP_SIZE) >> shift_low)  & 0x0000FFFF;
+    const int ret_high = (__shfl_sync(0xFFFFFFFFULL, x, src_laneid_high, WARP_SIZE) << shift_high) & 0xFFFF0000;
 
     return ret_low | ret_high;
 }
@@ -695,7 +695,7 @@ namespace ggml_cuda_mma {
             // On Volta FP16 and FP32 tiles have a different memory layout,
             //     for the conversion threads with an offset of 2 need to exchange half their values:
             ret.x[l0/2 + (((threadIdx.x % 4) / 2) ^ 1)] = __shfl_xor_sync(
-                0xFFFFFFFF, ret.x[l0/2 + (((threadIdx.x % 4) / 2) ^ 1)], 2, WARP_SIZE);
+                0xFFFFFFFFULL, ret.x[l0/2 + (((threadIdx.x % 4) / 2) ^ 1)], 2, WARP_SIZE);
         }
         return ret;
     }

--- a/ggml/src/ggml-cuda/mmid.cu
+++ b/ggml/src/ggml-cuda/mmid.cu
@@ -78,7 +78,7 @@ static __global__ void mm_ids_helper(
             int it_compact_add_lower = 0;
 #pragma unroll
             for (int offset = neu_padded; offset < warp_size; offset += neu_padded) {
-                const int tmp = __shfl_up_sync(0xFFFFFFFF, it_compact_add_self, offset, warp_size);
+                const int tmp = __shfl_up_sync(0xFFFFFFFFULL, it_compact_add_self, offset, warp_size);
                 if (threadIdx.x >= static_cast<unsigned int>(offset)) {
                     it_compact_add_lower += tmp;
                 }
@@ -89,7 +89,7 @@ static __global__ void mm_ids_helper(
             }
 
             // The thread with the highest index in the warp always has the sum over the whole warp, use it to increment all threads:
-            it_compact += __shfl_sync(0xFFFFFFFF, it_compact_add_lower + it_compact_add_self, warp_size - 1, warp_size);
+            it_compact += __shfl_sync(0xFFFFFFFFULL, it_compact_add_lower + it_compact_add_self, warp_size - 1, warp_size);
         }
     }
     nex_prev = warp_reduce_sum<warp_size>(nex_prev);

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -128,7 +128,7 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
         float amax = fabsf(xi);
 #pragma unroll
         for (int mask = 16; mask > 0; mask >>= 1) {
-            amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, mask, WARP_SIZE));
+            amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFFULL, amax, mask, WARP_SIZE));
         }
 
         const uint8_t e = compute_e8m0_scale(amax);
@@ -138,10 +138,10 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
 #if CUDART_VERSION >= 12080
         const float scaled_val = xi * inv_s;
 
-        const float val0 = __shfl_sync(0xFFFFFFFF, scaled_val, base, WARP_SIZE);
-        const float val1 = __shfl_sync(0xFFFFFFFF, scaled_val, base + 16, WARP_SIZE);
-        const float val2 = __shfl_sync(0xFFFFFFFF, scaled_val, base + 1, WARP_SIZE);
-        const float val3 = __shfl_sync(0xFFFFFFFF, scaled_val, base + 17, WARP_SIZE);
+        const float val0 = __shfl_sync(0xFFFFFFFFULL, scaled_val, base, WARP_SIZE);
+        const float val1 = __shfl_sync(0xFFFFFFFFULL, scaled_val, base + 16, WARP_SIZE);
+        const float val2 = __shfl_sync(0xFFFFFFFFULL, scaled_val, base + 1, WARP_SIZE);
+        const float val3 = __shfl_sync(0xFFFFFFFFULL, scaled_val, base + 17, WARP_SIZE);
 
         if (lane_in_group == 0) {
             __nv_fp4x4_e2m1 fp4_packed(make_float4(val0, val1, val2, val3));
@@ -152,10 +152,10 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
         // Fallback: manual FP4 conversion using LUT
         const uint8_t q_val = ggml_cuda_float_to_fp4_e2m1(xi, inv_s);
 
-        const uint8_t q_lo_0 = __shfl_sync(0xFFFFFFFF, q_val, base,      WARP_SIZE);
-        const uint8_t q_lo_1 = __shfl_sync(0xFFFFFFFF, q_val, base + 1,  WARP_SIZE);
-        const uint8_t q_hi_0 = __shfl_sync(0xFFFFFFFF, q_val, base + 16, WARP_SIZE);
-        const uint8_t q_hi_1 = __shfl_sync(0xFFFFFFFF, q_val, base + 17, WARP_SIZE);
+        const uint8_t q_lo_0 = __shfl_sync(0xFFFFFFFFULL, q_val, base,      WARP_SIZE);
+        const uint8_t q_lo_1 = __shfl_sync(0xFFFFFFFFULL, q_val, base + 1,  WARP_SIZE);
+        const uint8_t q_hi_0 = __shfl_sync(0xFFFFFFFFULL, q_val, base + 16, WARP_SIZE);
+        const uint8_t q_hi_1 = __shfl_sync(0xFFFFFFFFULL, q_val, base + 17, WARP_SIZE);
 
         if (lane_in_group == 0) {
             char2 q;
@@ -214,7 +214,7 @@ static __global__ void quantize_mmq_q8_1(
     // Exchange max. abs. value between vals_per_scale/4 threads.
 #pragma unroll
     for (int offset = vals_per_scale/8; offset > 0; offset >>= 1) {
-        amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, offset, WARP_SIZE));
+        amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFFULL, amax, offset, WARP_SIZE));
     }
 
     float sum;
@@ -224,7 +224,7 @@ static __global__ void quantize_mmq_q8_1(
         // Calculate sums across vals_per_sum/4 threads.
 #pragma unroll
         for (int offset = vals_per_sum/8; offset > 0; offset >>= 1) {
-            sum += __shfl_xor_sync(0xFFFFFFFF, sum, offset, WARP_SIZE);
+            sum += __shfl_xor_sync(0xFFFFFFFFULL, sum, offset, WARP_SIZE);
         }
     }
 

--- a/ggml/src/ggml-cuda/topk-moe.cu
+++ b/ggml/src/ggml-cuda/topk-moe.cu
@@ -180,9 +180,9 @@ __launch_bounds__(4 * WARP_SIZE, 1) __global__ void topk_moe_cuda(const float * 
 
 #pragma unroll
             for (int mask = WARP_SIZE / 2; mask > 0; mask /= 2) {
-                const float val    = __shfl_xor_sync(0xFFFFFFFF, max_val, mask, WARP_SIZE);
-                const float val_s  = __shfl_xor_sync(0xFFFFFFFF, max_val_s, mask, WARP_SIZE);
-                const int   expert = __shfl_xor_sync(0xFFFFFFFF, max_expert, mask, WARP_SIZE);
+                const float val    = __shfl_xor_sync(0xFFFFFFFFULL, max_val, mask, WARP_SIZE);
+                const float val_s  = __shfl_xor_sync(0xFFFFFFFFULL, max_val_s, mask, WARP_SIZE);
+                const int   expert = __shfl_xor_sync(0xFFFFFFFFULL, max_expert, mask, WARP_SIZE);
                 if (val_s > max_val_s || (val_s == max_val_s && expert < max_expert)) {
                     max_val    = val;
                     max_val_s  = val_s;
@@ -205,8 +205,8 @@ __launch_bounds__(4 * WARP_SIZE, 1) __global__ void topk_moe_cuda(const float * 
 
 #pragma unroll
             for (int mask = WARP_SIZE / 2; mask > 0; mask /= 2) {
-                const float val    = __shfl_xor_sync(0xFFFFFFFF, max_val, mask, WARP_SIZE);
-                const int   expert = __shfl_xor_sync(0xFFFFFFFF, max_expert, mask, WARP_SIZE);
+                const float val    = __shfl_xor_sync(0xFFFFFFFFULL, max_val, mask, WARP_SIZE);
+                const int   expert = __shfl_xor_sync(0xFFFFFFFFULL, max_expert, mask, WARP_SIZE);
                 if (val > max_val || (val == max_val && expert < max_expert)) {
                     max_val    = val;
                     max_expert = expert;

--- a/ggml/src/ggml-cuda/turbo-quant-cuda.cuh
+++ b/ggml/src/ggml-cuda/turbo-quant-cuda.cuh
@@ -1,6 +1,12 @@
 #pragma once
+// Route vendor headers (cuda_runtime, cuda_fp16) through the shim for
+// CUDA/HIP portability — see ggml-cuda/vendors/{cuda,hip}.h.
+#if defined(GGML_USE_HIP)
+#include "vendors/hip.h"
+#else
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#endif
 #include "ggml-common.h"
 
 // === InnerQ per-channel equalization ===
@@ -758,11 +764,11 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
     }
     if (sid < 32) {
         float v = cost[sid];
-        v += __shfl_down_sync(0xFFFFFFFF, v, 16);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 8);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 4);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 2);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 1);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 16);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 8);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 4);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 2);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 1);
         if (sid == 0) cost[0] = v;
     }
     __syncthreads();
@@ -834,8 +840,8 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
         int my_idx = sid;
         #pragma unroll
         for (int offset = 16; offset > 0; offset >>= 1) {
-            float other_cost = __shfl_xor_sync(0xFFFFFFFF, my_cost, offset);
-            int other_idx = __shfl_xor_sync(0xFFFFFFFF, my_idx, offset);
+            float other_cost = __shfl_xor_sync(0xFFFFFFFFULL, my_cost, offset);
+            int other_idx = __shfl_xor_sync(0xFFFFFFFFULL, my_idx, offset);
             if (other_cost < my_cost) { my_cost = other_cost; my_idx = other_idx; }
         }
         if (sid % 32 == 0) {
@@ -899,11 +905,11 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
     }
     if (sid < 32) {
         float v = cost[sid];
-        v += __shfl_down_sync(0xFFFFFFFF, v, 16);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 8);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 4);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 2);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 1);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 16);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 8);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 4);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 2);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 1);
         if (sid == 0) cost[0] = v;
     }
     __syncthreads();
@@ -1064,11 +1070,11 @@ static __global__ void __launch_bounds__(256, 1) k_set_rows_turbo2_tcq(
     }
     if (sid < 32) {
         float v = cost[sid];
-        v += __shfl_down_sync(0xFFFFFFFF, v, 16);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 8);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 4);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 2);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 1);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 16);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 8);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 4);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 2);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 1);
         if (sid == 0) cost[0] = v;
     }
     __syncthreads();
@@ -1138,8 +1144,8 @@ static __global__ void __launch_bounds__(256, 1) k_set_rows_turbo2_tcq(
         int my_idx = sid;
         #pragma unroll
         for (int offset = 16; offset > 0; offset >>= 1) {
-            float other_cost = __shfl_xor_sync(0xFFFFFFFF, my_cost, offset);
-            int other_idx = __shfl_xor_sync(0xFFFFFFFF, my_idx, offset);
+            float other_cost = __shfl_xor_sync(0xFFFFFFFFULL, my_cost, offset);
+            int other_idx = __shfl_xor_sync(0xFFFFFFFFULL, my_idx, offset);
             if (other_cost < my_cost) { my_cost = other_cost; my_idx = other_idx; }
         }
         if (sid % 32 == 0) {
@@ -1204,11 +1210,11 @@ static __global__ void __launch_bounds__(256, 1) k_set_rows_turbo2_tcq(
     }
     if (sid < 32) {
         float v = cost[sid];
-        v += __shfl_down_sync(0xFFFFFFFF, v, 16);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 8);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 4);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 2);
-        v += __shfl_down_sync(0xFFFFFFFF, v, 1);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 16);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 8);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 4);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 2);
+        v += __shfl_down_sync(0xFFFFFFFFULL, v, 1);
         if (sid == 0) cost[0] = v;
     }
     __syncthreads();

--- a/ggml/src/ggml-cuda/turbo-sink.cu
+++ b/ggml/src/ggml-cuda/turbo-sink.cu
@@ -1,5 +1,7 @@
 #include "turbo-sink.cuh"
+#if !defined(GGML_USE_HIP)
 #include <cuda_runtime.h>
+#endif
 #include <cstdlib>
 #include <cstdio>
 #include <unordered_map>

--- a/ggml/src/ggml-cuda/turbo-sink.cuh
+++ b/ggml/src/ggml-cuda/turbo-sink.cuh
@@ -1,5 +1,9 @@
 #pragma once
+#if defined(GGML_USE_HIP)
+#include "vendors/hip.h"
+#else
 #include <cuda_fp16.h>
+#endif
 #include <cstdint>
 
 // Attention-sink token protection: store rotated fp16 values for the first N

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#define HIP_DISABLE_WARP_SYNC_BUILTINS 1
+// ROCm 7.2+ provides native C++ templates for __shfl_*_sync with default
+// width=warpSize, matching the CUDA API. We rely on those directly — the
+// legacy HIP_DISABLE_WARP_SYNC_BUILTINS guard from older forks conflicts
+// with them and is intentionally omitted here.
 #include <hip/hip_runtime.h>
 #include <hipblas/hipblas.h>
 #include <hip/hip_fp16.h>
@@ -28,11 +31,10 @@
 #define CU_MEM_LOCATION_TYPE_DEVICE hipMemLocationTypeDevice
 #define CU_MEM_ACCESS_FLAGS_PROT_READWRITE hipMemAccessFlagsProtReadWrite
 #define CU_CHECK(fn) {hipError_t err = fn; if(err != hipSuccess) { GGML_ABORT("HipVMM Failure: %s\n", hipGetErrorString(err)); }}
-#define __shfl_sync(mask, var, laneMask, width) __shfl(var, laneMask, width)
-#define __shfl_up_sync(mask, var, laneMask, width) __shfl_up(var, laneMask, width)
-#define __shfl_xor_sync(mask, var, laneMask, width) __shfl_xor(var, laneMask, width)
 #define __all_sync(mask, var) __all(var)
 #define __any_sync(mask, var) __any(var)
+#define cudaMemcpyToSymbol     hipMemcpyToSymbol
+#define cudaMemcpyFromSymbol   hipMemcpyFromSymbol
 #define cublasStrsmBatched hipblasStrsmBatched
 #define cublasCreate hipblasCreate
 #define cublasDestroy hipblasDestroy


### PR DESCRIPTION
# ROCm 7.2 / RDNA3 build support + `gated_delta_net` perf fix

## Summary

This PR makes the fork buildable and usable on **AMD ROCm 7.2 / RDNA3 (gfx1100)**, tested end-to-end on an RX 7900 XTX with Qwen3.5-27B and Qwen3.6-27B targets.

Five commits:

1. **`vendors/hip.h`** — drop the legacy `#define __shfl_*_sync` macros that conflict with ROCm 7.2's native templates; add the missing `cudaMemcpy[From|To]Symbol` aliases used by `turbo-sink.cu`.
2. **`ggml-cuda/*`** — widen the `__shfl_*_sync` mask literals from `0xFFFFFFFF` to `0xFFFFFFFFULL`. ROCm 7.2 enforces `static_assert(sizeof(MaskT) == 8)` on the sync builtins. Mechanical change; no behavior difference on CUDA (implicit narrowing preserves the value).
3. **`turbo-quant-cuda.cuh`, `turbo-sink.{cu,cuh}`** — route the direct `<cuda_runtime.h>` / `<cuda_fp16.h>` includes through `ggml-cuda/vendors/hip.h` on HIP builds, matching the pattern already used by other kernels.
4. **`gated_delta_net.cu`** — `__launch_bounds__` set to `1 block/SM` on HIP. With 2 blocks/SM the compiler is forced under ~128 VGPR/lane and spills; 1 block/SM raises the budget to ~256 VGPR/lane and eliminates the spill. **+24 %** measured throughput on DDTree-style decode. CUDA unchanged.
5. **`README.md`** — adds a dedicated AMD (ROCm / HIP) build section with the tested cmake invocation and measured numbers. The existing NVIDIA block is unchanged.

Commits 1 and 2 are logically coupled (removing the legacy macros only works if the call sites pass a 64-bit mask). Commits 3, 4, 5 are independent and HIP-only.

## Measured performance (RX 7900 XTX, Qwen*-27B Q4_K_M, fibonacci/quicksort/knapsack prompts)

| Config | AR (tok/s) | DFlash (tok/s) | Speedup |
|---|---:|---:|---:|
| Qwen 3.5-27B | 27.09 | **50.92** | **×1.88** |
| Qwen 3.6-27B | 26.65 | **43.00** | **×1.61** |

The gated_delta_net fix alone lifts DFlash decode from ~40 tok/s to ~51 tok/s on the 3.5 config.

## How to build

```bash
cmake -B build-hip -S . -DGGML_HIP=ON -DAMDGPU_TARGETS=gfx1100 \
    -DCMAKE_BUILD_TYPE=Release -DLLAMA_BUILD_SERVER=ON \
    -DCMAKE_C_COMPILER=/opt/rocm/bin/amdclang \
    -DCMAKE_CXX_COMPILER=/opt/rocm/bin/amdclang++
cmake --build build-hip -j 8
```

## How to run (same as the CUDA recipe)

```bash
./build-hip/bin/llama-server \
    -m  /path/Qwen3.5-27B-target.Q4_K_M.gguf \
    -md /path/dflash-draft-q4_k_m.gguf \
    --spec-type dflash \
    -ngl 99 -ngld 99 \
    -np 1 -c 6048 -cd 256 \
    -fa on -b 256 -ub 64 \
    --host 0.0.0.0 --port 8080 --jinja
```

## Context

The `gated_delta_net` HIP perf fix is also documented upstream as [ggml-org/llama.cpp#20354](https://github.com/ggml-org/llama.cpp/issues/20354). This PR applies it to the fork's two kernel variants (chain and tree-mode).

## Tested on

- **Hardware**: AMD Radeon RX 7900 XTX (gfx1100, RDNA3, 24 GB VRAM)
- **Software**: Arch Linux, ROCm 7.2.0, amdclang 22.0.0
- **Models**: Qwen3.5-27B Q4_K_M + z-lab Qwen3.5-27B-DFlash drafter (Q4_K_M)
- **Entry points**: `llama-cli`, `llama-quantize`, `llama-server` (all functional)
- **Speculative mode**: `--spec-type dflash` with the fork's DFlash drafter support

## Not in this PR

- SWA layers for Qwen3.6 drafter. The real drafter config ships with 4× `sliding_attention` + 1× `full_attention`, but the current DFlash drafter graph builds a single `kq_mask` shared across all layers. Adding per-layer masks would improve long-context (>2048 tok) Qwen3.6 runs; on short prompts it has no measurable effect (n_ctx_draft=256 in the default recipe).
- `launch_bounds` tuning for other HIP kernels (mmq, fattn): attempted, did not yield measurable gains on this hardware.

## Disclosure

AI-assisted development was used for the mechanical parts (bulk mask widening, vendor-shim refactor). The kernel perf fix was driven by manual analysis of the spill pattern under `__launch_bounds__(..., 2)` on RDNA3 and cross-checked against upstream issue #20354. I can defend every line of these changes.
