### PR TITLE
server: fix context checkpoint restore for hybrid/recurrent models

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2598,6 +2598,12 @@ private:
                                             // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
                                             LOG_INF("slot %12.*s: id %2d | task %d | Checking checkpoint with [%d, %d] against %d...\n", 12,
                                                 func_name, (slot).id, ((slot).task ? (slot).task->id : -1), cur.pos_min, cur.pos_max, pos_min_thold);
+                                            // for hybrid/recurrent models (DeltaNet, Mamba), pos_min always equals
+                                            // the full sequence length, so the SWA-based pos_min check always fails.
+                                            // use pos_max <= pos_next instead to find the most recent valid checkpoint.
+                                            if (llama_model_is_recurrent(model) || llama_model_is_hybrid(model)) {
+                                                return cur.pos_max <= pos_next;
+                                            }
                                             return cur.pos_min < pos_min_thold;
                                         }
                                     );
@@ -2839,7 +2845,9 @@ private:
                     const auto pos_max = llama_memory_seq_pos_max(llama_get_memory(ctx), slot.id);
 
                     // no need for empty or small checkpoints
-                    do_checkpoint = do_checkpoint && (pos_min >= 0 && slot.prompt.n_tokens() >= 64);
+                    // for hybrid/recurrent models, lower the checkpoint threshold so short prompts also get checkpointed
+                    const int checkpoint_min_tokens = (llama_model_is_recurrent(model) || llama_model_is_hybrid(model)) ? 4 : 64;
+                    do_checkpoint = do_checkpoint && (pos_min >= 0 && slot.prompt.n_tokens() >= checkpoint_min_tokens);
 
                     // do not checkpoint after mtmd chunks
                     do_checkpoint = do_checkpoint && !has_mtmd;


### PR DESCRIPTION
**Problem**

Hybrid/recurrent models like Qwen3.5-27B and Qwen3.6-27B (Gated DeltaNet 
architecture) force full prompt re-processing on every conversation turn. 
A 15K-token conversation takes ~15 seconds per turn instead of milliseconds, 
making multi-turn agentic workflows (OpenCode, Claude Code) practically unusable.

Root cause: two bugs in the checkpoint restore logic:

1. The checkpoint search uses `cur.pos_min < pos_min_thold` — but for recurrent 
models, `pos_min` always equals the full sequence length, so this check always 
fails and no checkpoint is ever restored.

2. The checkpoint creation threshold of 64 tokens prevents checkpoints from being 
created for short prompts, so there's nothing to restore even if the search worked.

**Fix**

- For hybrid/recurrent models: use `cur.pos_max <= pos_next` instead of the SWA-based `pos_min` check
- Lower the minimum checkpoint creation threshold from 64 to 4 tokens for hybrid/recurrent models

**Tested**

Qwen3.6-27B Q4_K_M on RTX 3090, multi-turn via OpenCode. Second turn now 
processes only new tokens (31 tokens, 115ms) instead of full re-processing 
(12K tokens, ~11 seconds).

**Related upstream issues**
- ggml-org/llama.cpp#20225
- ggml-org/llama.cpp#19394
- ggml-org/llama.cpp#19690

Authored-by: Gastón Parravicini