### PR TITLE
cuda: optimize turbo3 TCQ set_rows

### DIFF
--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -525,20 +525,44 @@ static void set_rows_cuda(ggml_backend_cuda_context & ctx, const ggml_tensor * s
                 init_tcq_error_dump(ctx.device);
             }
         }
-        // TCQ Viterbi encode: 512 threads per block, global bt buffer (128×512 bytes/block)
+        // TCQ Viterbi encode: 512 threads per block. The TCQ3 backtrace stores
+        // one predecessor for each 64-state low-bit group per step.
         const int64_t s01_f = nb01/sizeof(float); const int64_t s02_f = nb02/sizeof(float); const int64_t s03_f = nb03/sizeof(float);
         const int64_t s10_i = nb10/sizeof(idx_t); const int64_t s11_i = nb11/sizeof(idx_t); const int64_t s12_i = nb12/sizeof(idx_t);
         const int iq_is_k = (strncmp(dst->name, "cache_k_", 8) == 0) ? 1 : 0;
         if (ne_total_groups > 0 && ne00 > 0 && ne01 > 0 && ne02 > 0 && ne11 > 0 && ne12 > 0) {
-            ensure_tcq_bt_buf(ctx.device, ne_total_groups * 128 * 512);
+            static int tcq3_use_shared_bt[GGML_CUDA_MAX_DEVICES] = {};
+            static bool tcq3_bt_checked[GGML_CUDA_MAX_DEVICES] = {};
+            constexpr int tcq3_bt_shared_bytes = 128 * 64;
+            if (!tcq3_bt_checked[ctx.device]) {
+                tcq3_bt_checked[ctx.device] = true;
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+                const char * tcq_shared_bt_env = getenv("TURBO_TCQ_SHARED_BT");
+                if (!tcq_shared_bt_env || atoi(tcq_shared_bt_env) != 0) {
+                    int max_shared_optin = 0;
+                    CUDA_CHECK(cudaDeviceGetAttribute(&max_shared_optin, cudaDevAttrMaxSharedMemoryPerBlockOptin, ctx.device));
+                    if (max_shared_optin >= tcq3_bt_shared_bytes) {
+                        CUDA_SET_SHARED_MEMORY_LIMIT(k_set_rows_turbo3_tcq<idx_t>, tcq3_bt_shared_bytes);
+                        tcq3_use_shared_bt[ctx.device] = 1;
+                        fprintf(stderr, "TCQ encode: using shared-memory backtrace (%d bytes/block)\n", tcq3_bt_shared_bytes);
+                    } else {
+                        fprintf(stderr, "TCQ encode: shared-memory backtrace unavailable, only %d bytes/block are available\n", max_shared_optin);
+                    }
+                }
+#endif
+            }
+            if (!tcq3_use_shared_bt[ctx.device]) {
+                ensure_tcq_bt_buf(ctx.device, ne_total_groups * 128 * 64);
+            }
             const uint3 ne00_fd = init_fastdiv_values((uint32_t) ne00);
             const uint3 ne01_fd = init_fastdiv_values((uint32_t) ne01);
             const uint3 ne02_fd = init_fastdiv_values((uint32_t) ne02);
             const uint3 ne11_fd = init_fastdiv_values((uint32_t) ne11);
             const uint3 ne12_fd = init_fastdiv_values((uint32_t) ne12);
-            k_set_rows_turbo3_tcq<idx_t><<<(int)ne_total_groups, 512, 0, stream>>>(
+            const int shared_bytes = tcq3_use_shared_bt[ctx.device] ? tcq3_bt_shared_bytes : 0;
+            k_set_rows_turbo3_tcq<idx_t><<<(int)ne_total_groups, 512, shared_bytes, stream>>>(
                 src0_d, src1_d, (block_turbo3_tcq *)dst->data,
-                ne_total_groups, tcq_bt_buf[ctx.device], ne00, ne01, ne02, ne10, ne11, ne12, ne13,
+                ne_total_groups, tcq_bt_buf[ctx.device], tcq3_use_shared_bt[ctx.device], ne00, ne01, ne02, ne10, ne11, ne12, ne13,
                 s01_f, s02_f, s03_f, s10_i, s11_i, s12_i, iq_is_k, nb1, nb2, nb3,
                 ne00_fd, ne01_fd, ne02_fd, ne11_fd, ne12_fd);
         }

--- a/ggml/src/ggml-cuda/turbo-quant-cuda.cuh
+++ b/ggml/src/ggml-cuda/turbo-quant-cuda.cuh
@@ -697,6 +697,7 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
         const float * __restrict__ src0, const idx_t * __restrict__ src1,
         block_turbo3_tcq * __restrict__ dst, const int64_t ne_total_groups,
         uint8_t * __restrict__ bt_buf,
+        const int use_shared_bt,
         const int64_t ne00, const int64_t ne01, const int64_t ne02,
         const int64_t ne10, const int64_t ne11, const int64_t ne12, const int64_t ne13,
         const int64_t s01, const int64_t s02, const int64_t s03,
@@ -728,12 +729,17 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
     // x[128]     : rotated+normalized input (also reused as outputs[] after Viterbi)
     // cost[512]  : path costs buffer A (also reused for reductions)
     // cost_b[512]: path costs buffer B (double-buffering eliminates 2/3 of syncs)
-    // Backtrace: bt_buf in global memory, 128×512 bytes per block (byte-packed)
+    // Backtrace: one predecessor byte for each of the 64 low-state groups per
+    // step. The predecessor is independent of the output bits in sid[8:6], so
+    // storing 128×64 bytes is equivalent to the older 128×512 layout.
+    extern __shared__ uint8_t bt_shared[];
     __shared__ float x[128];
     __shared__ float cost[512];
     __shared__ float cost_b[512];
     __shared__ int warp_min_idx[16];
     __shared__ float warp_min_cost[16];
+    __shared__ float pred_min_cost[64];
+    __shared__ uint8_t pred_min_p[64];
     __shared__ int shared_initial_state;
 
     if (sid < 128) x[sid] = grp_src[sid];
@@ -778,17 +784,30 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
     if (sid < 128) x[sid] *= inv_norm;
     __syncthreads();
 
-    // FWHT
-    if (sid < 128) x[sid] *= d_turbo_wht_signs1[sid];
-    __syncthreads();
-    for (int h = 1; h < 128; h *= 2) {
-        if (sid < 64) {
-            int j = (sid / h) * (2 * h) + (sid % h);
-            float a = x[j], b = x[j + h];
-            x[j] = a + b; x[j + h] = a - b;
+    // FWHT. The first five stages are contained within each 32-lane warp, so
+    // use warp shuffles and only synchronize for the two cross-warp stages.
+    if (sid < 128) {
+        float v = x[sid] * d_turbo_wht_signs1[sid];
+        const int lane = sid & 31;
+#pragma unroll
+        for (int h = 1; h < 32; h <<= 1) {
+            const float other = __shfl_xor_sync(0xFFFFFFFFULL, v, h);
+            v = (lane & h) ? (other - v) : (v + other);
         }
-        __syncthreads();
+        x[sid] = v;
     }
+    __syncthreads();
+    if (sid < 64) {
+        const int j = ((sid >> 5) << 6) + (sid & 31);
+        float a = x[j], b = x[j + 32];
+        x[j] = a + b; x[j + 32] = a - b;
+    }
+    __syncthreads();
+    if (sid < 64) {
+        float a = x[sid], b = x[sid + 64];
+        x[sid] = a + b; x[sid + 64] = a - b;
+    }
+    __syncthreads();
     constexpr float inv_sqrt_128 = 0.08838834764831845f;
     if (sid < 128) x[sid] *= inv_sqrt_128 * d_turbo_wht_signs2[sid];
     __syncthreads();
@@ -800,8 +819,7 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
     float saved_norm = cost[0];
 
     // Viterbi forward pass: double-buffered cost (1 sync/step, was 3)
-    // Backtrace in global memory: byte-packed, no nibble conflicts
-    uint8_t * bt = bt_buf + (int64_t)blockIdx.x * (128 * 512);
+    uint8_t * bt = use_shared_bt ? bt_shared : bt_buf + (int64_t)blockIdx.x * (128 * 64);
     cost[sid] = 0.0f;
     __syncthreads();
 
@@ -812,24 +830,32 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
 
         float xt = x[t];
 
-        // Right-shift trellis: ns = (prev >> 3) | (out << 6)
-        // Predecessors of sid: prev = ((sid & 0x3F) << 3) | p, for p = 0..7
-        int base_prev = (sid & 0x3F) << 3;
+        // Right-shift trellis: ns = (prev >> 3) | (out << 6). The best
+        // predecessor depends only on sid's low 6 bits, so compute those 64
+        // minima once instead of repeating the same 8-way scan for each out.
+        if (sid < 64) {
+            const int base_prev = sid << 3;
+            float best = cost_rd[base_prev];
+            int best_p = 0;
+#pragma unroll
+            for (int p = 1; p < 8; p++) {
+                float c = cost_rd[base_prev | p];
+                if (c < best) {
+                    best = c;
+                    best_p = p;
+                }
+            }
+            pred_min_cost[sid] = best;
+            pred_min_p[sid] = (uint8_t) best_p;
+            bt[t * 64 + sid] = (uint8_t) best_p;
+        }
+        __syncthreads();
+
+        const int pred_idx = sid & 0x3F;
         float dist = xt - d_turbo3_tcq_codebook[sid];
         dist = dist * dist;
 
-        float best = 1e30f;
-        int best_p = 0;
-        for (int p = 0; p < 8; p++) {
-            float c = cost_rd[base_prev | p];
-            if (c < best) {
-                best = c;
-                best_p = p;
-            }
-        }
-
-        cost_wr[sid] = best + dist;
-        bt[t * 512 + sid] = (uint8_t)best_p;
+        cost_wr[sid] = pred_min_cost[pred_idx] + dist;
         __syncthreads();
     }
     // After 128 steps (even count): final costs are in cost[] (step 127 writes to cost)
@@ -870,7 +896,7 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
         int state = shared_initial_state;
         for (int t = 127; t >= 0; t--) {
             outputs[t] = (uint8_t)(state >> 6);
-            int p = bt[t * 512 + state];
+            int p = bt[t * 64 + (state & 0x3F)];
             state = ((state & 0x3F) << 3) | p;
         }
         shared_initial_state = state;
@@ -917,18 +943,29 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
     float corrected_norm = (recon_norm > 1e-10f) ? saved_norm / recon_norm : saved_norm;
     corrected_norm *= innerq_is_k ? d_tcq_norm_alpha : d_tcq_norm_alpha_v;
 
-    // Serial bitpack — byte-alignment prevents parallel atomicOr
-    if (sid == 0) {
-        for (int j = 0; j < 49; j++) dst_blk->qs[j] = 0;
-        dst_blk->qs[0] = (uint8_t)((shared_initial_state >> 3) & 0x3F);
-        for (int t = 0; t < 128; t++) {
-            const int bit_pos = 6 + t * 3;
-            const int byte_idx = bit_pos / 8;
-            const int bit_off = bit_pos % 8;
-            const int out = outputs[t] & 0x7;
-            dst_blk->qs[byte_idx] |= (uint8_t)(out << bit_off);
-            if (bit_off > 5) dst_blk->qs[byte_idx + 1] |= (uint8_t)(out >> (8 - bit_off));
+    // Parallel bitpack: qs stores 6 initial-state bits followed by 128 3-bit
+    // output symbols. Each byte is independent, so avoid the old serial OR loop.
+    if (sid < 49) {
+        const int init_bits = (shared_initial_state >> 3) & 0x3F;
+        uint8_t packed = 0;
+#pragma unroll
+        for (int bit = 0; bit < 8; bit++) {
+            const int pos = sid * 8 + bit;
+            int v = 0;
+            if (pos < 6) {
+                v = (init_bits >> pos) & 1;
+            } else {
+                const int sym_bit_pos = pos - 6;
+                const int sym_idx = sym_bit_pos / 3;
+                if (sym_idx < 128) {
+                    v = (outputs[sym_idx] >> (sym_bit_pos % 3)) & 1;
+                }
+            }
+            packed |= (uint8_t)(v << bit);
         }
+        dst_blk->qs[sid] = packed;
+    }
+    if (sid == 0) {
         dst_blk->norm = __float2half(corrected_norm);
     }
 }

--- a/ggml/src/ggml-cuda/turbo-quant-cuda.cuh
+++ b/ggml/src/ggml-cuda/turbo-quant-cuda.cuh
@@ -739,7 +739,6 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
     __shared__ int warp_min_idx[16];
     __shared__ float warp_min_cost[16];
     __shared__ float pred_min_cost[64];
-    __shared__ uint8_t pred_min_p[64];
     __shared__ int shared_initial_state;
 
     if (sid < 128) x[sid] = grp_src[sid];
@@ -846,7 +845,6 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
                 }
             }
             pred_min_cost[sid] = best;
-            pred_min_p[sid] = (uint8_t) best_p;
             bt[t * 64 + sid] = (uint8_t) best_p;
         }
         __syncthreads();
@@ -876,13 +874,21 @@ static __global__ void __launch_bounds__(512, 1) k_set_rows_turbo3_tcq(
         }
     }
     __syncthreads();
-    if (sid == 0) {
-        float best = warp_min_cost[0];
-        int best_idx = warp_min_idx[0];
-        for (int w = 1; w < 16; w++) {
-            if (warp_min_cost[w] < best) { best = warp_min_cost[w]; best_idx = warp_min_idx[w]; }
+    if (sid < 32) {
+        float best = (sid < 16) ? warp_min_cost[sid] : 3.4028234663852886e38f;
+        int best_idx = (sid < 16) ? warp_min_idx[sid] : 0;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            float other_cost = __shfl_down_sync(0xFFFFFFFFULL, best, offset);
+            int other_idx = __shfl_down_sync(0xFFFFFFFFULL, best_idx, offset);
+            if (other_cost < best) {
+                best = other_cost;
+                best_idx = other_idx;
+            }
         }
-        shared_initial_state = best_idx; // temporarily: best final state (becomes initial after backtrack)
+        if (sid == 0) {
+            shared_initial_state = best_idx; // temporarily: best final state (becomes initial after backtrack)
+        }
     }
     __syncthreads();
 


### PR DESCRIPTION
Optimizes the CUDA `k_set_rows_turbo3_tcq` encoder path while preserving the TCQ3 bitstream.

Changes:
- Compact TCQ3 Viterbi backtrace from `128 * 512` bytes per group to `128 * 64`.
- Compute predecessor minima once per 64 low-state groups instead of redundantly for every state.
- Use an 8 KiB shared-memory backtrace by default when available, with `TURBO_TCQ_SHARED_BT=0` fallback.
- Parallelize final TCQ bit packing across bytes.
- Use warp shuffles for the intra-warp stages of the 128-point FWHT while preserving the original reduction/norm order.

Measured on RTX 4070 Ti SUPER, Qwen3.6 27B IQ4_XS, `-ctk turbo3_tcq -ctv turbo3_tcq -p 15000 -n 128`:

- Before: ~1490 tok/s
- After: 1580.51 tok/s

Nsight `k_set_rows_turbo3_tcq`:

- Before: 7.262 s total, 1.254 ms avg
- After: 4.216 s total, 0.728 ms avg

Validation:

- Compared against the pre-optimization encoder with `TURBO_TCQ_DUMP_ERRORS=4096`.
- 4096 groups matched exactly.
- TCQ output symbols matched exactly: 0 mismatches.
- Post-FWHT normalized values matched bit-for-bit: max abs diff 0.0.

Note: the shared-memory backtrace default was measured on an RTX 4070 Ti SUPER. The env override `TURBO_TCQ_SHARED_BT=0` is kept because broader GPU validation would be useful.