### PR TITLE
fix: set device before hipStreamWaitEvent in multi-GPU pipeline parallel

### DIFF
--- a/ggml/src/ggml-cuda/cross-ring-interleave.cu
+++ b/ggml/src/ggml-cuda/cross-ring-interleave.cu
@@ -12,6 +12,7 @@
 // expected by the drafter's target_hidden tensor, avoiding the CPU round-trip.
 
 struct dflash_cross_ring_gpu {
+    int device;               // CUDA device where ring buffers are allocated
     int n_layers;
     int n_embd;
     int ring_size;
@@ -54,6 +55,7 @@ extern "C" void * dflash_cross_ring_gpu_alloc(int n_layers, int n_embd, int ring
     }
 
     auto * ring = new dflash_cross_ring_gpu();
+    cudaGetDevice(&ring->device);
     ring->n_layers  = n_layers;
     ring->n_embd    = n_embd;
     ring->ring_size = ring_size;
@@ -123,6 +125,10 @@ extern "C" void dflash_cross_ring_gpu_write(
     if (layer < 0 || layer >= ring->n_layers) return;
     if (n_tokens <= 0) return;
 
+    // Ensure cudaStreamPerThread belongs to the ring's device regardless of
+    // which GPU the caller (target model decode) last set as current.
+    (void)cudaSetDevice(ring->device);
+
     float * dst = ring->h_layer_ptrs[layer];
     const size_t stride = (size_t)n_embd * sizeof(float);
 
@@ -149,6 +155,8 @@ extern "C" const float * dflash_cross_ring_gpu_interleave(
 
     int cross_len = filled < ctx_window ? filled : ctx_window;
     if (cross_len <= 0) return nullptr;
+
+    (void)cudaSetDevice(ring->device);
 
     int read_start = ((write_pos - cross_len) % ring->ring_size + ring->ring_size) % ring->ring_size;
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4088,6 +4088,7 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
 static void ggml_backend_cuda_event_record(ggml_backend_t backend, ggml_backend_event_t event) {
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
 
+    ggml_cuda_set_device(cuda_ctx->device);
     CUDA_CHECK(cudaEventRecord((cudaEvent_t)event->context, cuda_ctx->stream()));
 }
 
@@ -4095,6 +4096,10 @@ static void ggml_backend_cuda_event_wait(ggml_backend_t backend, ggml_backend_ev
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
 
     if (ggml_backend_is_cuda(backend)) {
+        // ROCm requires current device to match the stream's device for hipStreamWaitEvent.
+        // In pipeline-parallel multi-GPU, the scheduler alternates between devices and may
+        // call event_wait with a stale current device from the previous split.
+        ggml_cuda_set_device(cuda_ctx->device);
         CUDA_CHECK(cudaStreamWaitEvent(cuda_ctx->stream(), (cudaEvent_t)event->context, 0));
     } else {
 #if 0


### PR DESCRIPTION
## Overview

ROCm 7.x requires the current device to match a stream's device before calling hipStreamWaitEvent. In pipeline-parallel configs (two GPUs with -ts 1,1), the ggml scheduler alternates splits across devices. After a split runs on GPU 1, the current device is 1 -- but the scheduler may then call ggml_backend_cuda_event_wait for GPU 0's backend without switching devices first. This causes hipStreamWaitEvent to fail with "illegal memory access".

Fix: add ggml_cuda_set_device(cuda_ctx->device) at the top of both ggml_backend_cuda_event_record and ggml_backend_cuda_event_wait to ensure the current device always matches the stream and event.

Also fix dflash_cross_ring_gpu_write and dflash_cross_ring_gpu_interleave in cross-ring-interleave.cu: these used cudaStreamPerThread without setting the device first. The GPU ring buffer is allocated on one device, but the target model decode may leave a different device current when ring_write is called. Added a device field to the ring struct (captured at alloc time with cudaGetDevice) and call cudaSetDevice before each cudaStreamPerThread operation so the H2D memcpy and interleave kernel land on the right device.

Tested on ROCm 7.2.1 with two R9700 GPUs, Qwen3.6-27B + DFlash drafter using -ts 1,1. Before this patch: crash on the second draft cycle. After: stable.

# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
