### PR TITLE
Add Windows ROCm 7.13 build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cmake --build build -j$(nproc)
 ```
 
 #### [For Windows ROCM](https://github.com/lemonade-sdk/llamacpp-rocm/blob/main/docs/manual_instructions.md)
-Test on ROCM 7.13 + AMD Radeon AI PRO R9700
+Test on ROCm 7.13 + AMD Radeon AI PRO R9700
 
 ## Recommended configurations
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ cmake -B build \
 cmake --build build -j$(nproc)
 ```
 
+#### [For Windows ROCM](https://github.com/lemonade-sdk/llamacpp-rocm/blob/main/docs/manual_instructions.md)
+Test on ROCM 7.13 + AMD Radeon AI PRO R9700
+
 ## Recommended configurations
 
 ### turbo4 (4.25 bpv) -- lossless quality, great compression

--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -76,6 +76,8 @@ else()
         ../ggml-cuda/template-instances/fattn-vec-instance-q4_0-q4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-bf16-bf16.cu)
+    file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-vec-instance-*turbo*.cu")
+    list(APPEND GGML_SOURCES_ROCM ${SRCS})
 endif()
 
 ggml_add_backend_library(ggml-hip

--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -76,8 +76,10 @@ else()
         ../ggml-cuda/template-instances/fattn-vec-instance-q4_0-q4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-bf16-bf16.cu)
-    file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-vec-instance-*turbo*.cu")
-    list(APPEND GGML_SOURCES_ROCM ${SRCS})
+    if (WIN32)
+        file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-vec-instance-*turbo*.cu")
+        list(APPEND GGML_SOURCES_ROCM ${SRCS})
+    endif()
 endif()
 
 ggml_add_backend_library(ggml-hip


### PR DESCRIPTION
## Overview
Edit cmake script to make ROCm 7.13 compile on windows with AMD GPU, I add win32 guard since my pc not available to install any linux distro.

## Additional information
Tested on
Hardware: AMD Radeon AI PRO R9700 (gfx1201, RDNA4, 32 GB VRAM)
OS: Windows 11 25H2
Software: ROCm 7.13
Models: Qwen3.5-27B Q4_K_M

command
```
# no dflash
.\llama-server.exe -ngl 999 --port 3000 -c 8192 -m "F:\models\Qwen3.5-27B-Q4_K_M.gguf" -sm none -mg 1 -fa on --reasoning off
# dflash
.\llama-server.exe -ngl 999 --port 3000 -c 8192 -np 1 -sm none -mg 1 --reasoning off -fa on -m "F:\models\Qwen3.5-27B-Q4_K_M.gguf" -md "F:\models\dflash-draft-q4_k_m.gguf" -ngld 99 --draft-max 16 --spec-type dflash -np 1
```
prompt
``` Implement a word-guessing Hangman game in JS Canvas. ```

## Results

| Run | Prompt eval time (ms) | Prompt tokens | Prompt ms/token | Prompt tokens/sec | Eval time (ms) | Eval tokens | Eval ms/token | Eval tokens/sec | Total time (ms) | Total tokens |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline | 152.07 | 25 | 6.08 | 164.40 | 89028.54 | 2566 | 34.70 | 28.82 | 89180.61 | 2591 |
| turbo4 | 155.46 | 25 | 6.22 | 160.81 | 78341.20 | 2139 | 36.63 | 27.30 | 78496.66 | 2164 |
| dflash | 161.16 | 25 | 6.45 | 155.13 | 61626.67 | 2967 | 20.77 | 48.14 | 61787.82 | 2992 |
| dflash turbo4 | 166.71 | 25 | 6.67 | 149.96 | 47596.95 | 2332 | 20.41 | 48.99 | 47763.67 | 2357 |

## Draft Acceptance

| Run | Acceptance rate | Accepted | Generated |
| --- | ---: | ---: | ---: |
| dflash | 0.27292 | 2408 | 8823 |
| dflash turbo4 | 0.29091 | 1897 | 6521 |


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES format test result from llama server log to markdown table