### PR TITLE
cuda: tune Ada MMQ tile cap for small quants

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -122,7 +122,10 @@ static int get_mmq_x_max_host_for_type(const int cc) {
 
     if (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_ADA_LOVELACE) {
         switch (type) {
+            case GGML_TYPE_IQ2_XXS:
             case GGML_TYPE_IQ2_S:
+            case GGML_TYPE_IQ3_XXS:
+            case GGML_TYPE_IQ3_S:
             case GGML_TYPE_Q3_K:
                 return mmq_x_max < 64 ? mmq_x_max : 64;
             default:

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -116,6 +116,23 @@ static int get_mmq_x_max_host(const int cc) {
 #endif // GGML_CUDA_FORCE_MMQ
 }
 
+template <ggml_type type>
+static int get_mmq_x_max_host_for_type(const int cc) {
+    const int mmq_x_max = get_mmq_x_max_host(cc);
+
+    if (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_ADA_LOVELACE) {
+        switch (type) {
+            case GGML_TYPE_IQ2_S:
+            case GGML_TYPE_Q3_K:
+                return mmq_x_max < 64 ? mmq_x_max : 64;
+            default:
+                break;
+        }
+    }
+
+    return mmq_x_max;
+}
+
 static constexpr __device__ int get_mmq_x_max_device() {
 #if defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 128;
@@ -4060,7 +4077,7 @@ void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cuda
     const int warp_size = ggml_cuda_info().devices[id].warp_size;
     const int nwarps    = mmq_get_nwarps_host(cc, warp_size);
 
-    const int mmq_x_max = get_mmq_x_max_host(cc);
+    const int mmq_x_max = get_mmq_x_max_host_for_type<type>(cc);
     const int mmq_y = get_mmq_y_host(cc);
 
     int mmq_x_best  = 0;
@@ -4173,4 +4190,3 @@ void ggml_cuda_op_mul_mat_q(
     const int64_t src1_padded_row_size, cudaStream_t stream);
 
 bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t n_experts);
-


### PR DESCRIPTION
## Summary

- Add a type-aware host-side `MMQ_X` cap for NVIDIA Ada/Hopper-era GPUs.
- Limit `MMQ_X` to 64 for the small quant MMQ paths that benchmark faster on `sm_89`: `IQ2_XXS`, `IQ2_S`, `IQ3_XXS`, `IQ3_S`, and `Q3_K`.
- Keep the existing default `MMQ_X` selection for all other quant types.

## Rationale

On RTX 4070 Ti SUPER (`sm_89`), several small quant MMQ kernels lose prefill throughput with the default Ada `MMQ_X`. A broad/global cap regressed other paths, but a type-scoped cap improved large-context prefill across the affected quant mixes while leaving decode effectively unchanged.

## Benchmarks

Build flags:

```bash
cmake -B build-cuda-v1 \
  -DGGML_CUDA=ON \
  -DGGML_NATIVE=ON \
  -DGGML_CUDA_FA=ON \
  -DGGML_CUDA_FA_ALL_QUANTS=ON \
  -DCMAKE_BUILD_TYPE=Release
```

Benchmark shape:

```bash
llama-bench -ngl 999 -fa 1 \
  -ctk q8_0,turbo3_tcq -ctv q8_0,turbo3_tcq \
  -p 15000 -n 128
```

Control: `aecbbd5da`  
Feature: `239296c43`

### Qwen3.6-35B-A3B APEX I-Mini

`mudler/Qwen3.6-35B-A3B-APEX-GGUF / Qwen3.6-35B-A3B-APEX-I-Mini.gguf`

| K cache | V cache | control pp15000 | feature pp15000 | delta |
| --- | --- | ---: | ---: | ---: |
| q8_0 | q8_0 | 3970.64 | 4277.10 | +7.72% |
| q8_0 | turbo3_tcq | 3861.67 | 4151.31 | +7.50% |
| turbo3_tcq | q8_0 | 3851.03 | 4144.37 | +7.62% |
| turbo3_tcq | turbo3_tcq | 3748.39 | 4030.32 | +7.52% |

### Unsloth Qwen3.6-35B-A3B UD quants

`unsloth/Qwen3.6-35B-A3B-GGUF`, same benchmark shape.

| GGUF | affected tensors in mix | pp15000 delta range |
| --- | --- | ---: |
| `Qwen3.6-35B-A3B-UD-IQ1_M.gguf` | `IQ2_XXS`, `IQ2_S` | +6.27% to +6.67% |
| `Qwen3.6-35B-A3B-UD-IQ2_M.gguf` | `IQ2_XXS`, `IQ3_XXS` | +6.42% to +6.81% |
| `Qwen3.6-35B-A3B-UD-IQ3_XXS.gguf` | `IQ2_S`, `IQ3_XXS` | +7.67% to +7.92% |
| `Qwen3.6-35B-A3B-UD-IQ3_S.gguf` | `IQ2_S`, `IQ3_S` | +7.72% to +8.41% |
| `Qwen3.6-35B-A3B-UD-Q3_K_S.gguf` | `IQ3_XXS`, `IQ3_S` | +6.19% to +6.43% |

`Qwen3.6-35B-A3B-UD-Q3_K_M.gguf` did not fit the tested 16 GiB GPU with this all-GPU `p15000` setup, so it was not included in the result table.

Decode throughput stayed flat within run-to-run noise in these runs.

## Notes

- This is intentionally scoped to Ada/Hopper-era NVIDIA CCs via the existing `GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_ADA_LOVELACE` check.
- The cap is applied only at host launch selection time; the device-side default stays unchanged.
