### PR TITLE
ggml-cuda: fix cublasSgemm crash with zero-dim matrices in speculative decoding

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1493,6 +1493,16 @@ static void ggml_cuda_op_mul_mat_cublas(
     // ldc == nrows of the matrix that cuBLAS writes into
     int64_t ldc = id == ctx.device ? ne0 : row_diff;
 
+    // Guard: cuBLAS requires m >= 1, n >= 1, k >= 1 for Sgemm/GemmEx.
+    // During speculative decoding (DFlash/copyspec), draft verification can
+    // produce non-consecutive token positions which result in zero-size
+    // sub-matrices. cuBLAS treats these as invalid parameters and aborts
+    // with CUBLAS_STATUS_INVALID_VALUE. Zero-size GEMMs are defined as
+    // no-ops (no output written), matching OpenBLAS and MKL behavior.
+    if (row_diff == 0 || src1_ncols == 0 || ne10 == 0) {
+        return;
+    }
+
     const int cc = ggml_cuda_info().devices[id].cc;
 
     const bool supports_bf16 = GGML_CUDA_CC_IS_NVIDIA(cc) || GGML_CUDA_CC_IS_AMD(cc) ||

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1499,7 +1499,7 @@ static void ggml_cuda_op_mul_mat_cublas(
     // sub-matrices. cuBLAS treats these as invalid parameters and aborts
     // with CUBLAS_STATUS_INVALID_VALUE. Zero-size GEMMs are defined as
     // no-ops (no output written), matching OpenBLAS and MKL behavior.
-    if (row_diff == 0 || src1_ncols == 0 || ne10 == 0) {
+    if (row_diff == 0 || src1_ncols == 0 || ne10 == 0 || ne00 == 0 || ldc == 0) {
         return;
     }
 


### PR DESCRIPTION
Problem
-------
During speculative decoding (DFlash/copyspec), draft verification produces non-consecutive token positions which cause slot management to generate sub-matrix batches where row_diff evaluates to 0.

cuBLAS requires ldc >= max(1, m) where m = row_diff. When row_diff == 0, ldc is also 0 (ldc = row_diff when id != ctx.device), violating the cuBLAS precondition and triggering CUBLAS_STATUS_INVALID_VALUE.

Root cause
----------
No guard exists before the cublasSgemm/cublasGemmEx calls in ggml_cuda_op_mul_mat_cublas() to handle zero-dimension sub-matrices. Unlike OpenBLAS and MKL which define zero-size GEMMs as no-ops, cuBLAS treats them as invalid parameters and aborts.

Fix
---
Add an early-return guard after row_diff and ldc are computed. When any GEMM dimension (m, n, k) is zero, return immediately. This is safe because dst_dd_i is untouched and the caller does not read partial results.

Tested
------
Qwen3.6-27B Q4_K_M + DFlash draft, 55k context, RTX 3090 24GB
- Before: crash after ~27k tokens prefill during draft verification
- After:  stable generation, multiple sequential requests without crash

Related upstream issues
-----------------------
- ggml-org/llama.cpp#22105 (DFlash PR: hybrid models cannot discard rejected suffixes via seq_rm due to non-decomposable recurrent state)
- ggml-org/llama.cpp#19929 (non-consecutive token position with Qwen3.5 vision models on multi-GPU setups)
- ggml-org/llama.cpp#21569 (DFlash discussion: MoE hybrid limitations)

Authored-by: Gaston Parravicini

## Overview

Fix cublasSgemm/cublasGemmEx crash triggered during DFlash speculative decoding when draft verification produces zero-dimension sub-matrices. Adds an early-return guard in `ggml_cuda_op_mul_mat_cublas()` before any cuBLAS call.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 
-YES — Claude (Anthropic) was used to assist in root cause analysis, 
identifying the zero-dimension guard as the fix, and drafting the commit 
message. The patch was applied, compiled, and tested on hardware by the 
author. All code reviewed line by line before submission.

