### PR TITLE
fix: use M-RoPE position instead of token count for KV cache clearing in spec decoding

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2900,11 +2900,12 @@ void common_speculative_set_seq_id(common_speculative * spec, llama_seq_id seq_i
 }
 
 llama_tokens common_speculative_draft(
-        common_speculative * spec,
+        common_speculative              * spec,
         const common_params_speculative & params,
-        const llama_tokens & prompt_tgt,
-        llama_token id_last,
-        std::vector<float> * draft_log_probs) {
+        const llama_tokens              & prompt_tgt,
+        llama_token                       id_last,
+        std::vector<float>              * draft_log_probs,
+        llama_pos                         n_past_override) {
     llama_tokens result;
 
     if (spec == nullptr) {
@@ -2917,7 +2918,10 @@ llama_tokens common_speculative_draft(
     auto & dp = spec->dparams[0];
     dp.drafting = true;
     dp.n_max    = params.n_max;
-    dp.n_past   = (llama_pos)prompt_tgt.size();
+    // Use explicit n_past when provided (needed for vision tokens where
+    // actual positions exceed text token count due to M-RoPE spatial dims).
+    // Fall back to prompt_tgt.size() for text-only prompts.
+    dp.n_past   = n_past_override >= 0 ? n_past_override : (llama_pos)prompt_tgt.size();
     dp.id_last  = id_last;
     dp.prompt   = &prompt_tgt;
     dp.result   = &result;

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -94,7 +94,8 @@ llama_tokens common_speculative_draft(
         const common_params_speculative & params,
         const llama_tokens              & prompt_tgt,
         llama_token                       id_last,
-        std::vector<float>              * draft_log_probs = nullptr);
+        std::vector<float>              * draft_log_probs = nullptr,
+        llama_pos                         n_past_override = -1);
 
 // fork: batched multi-slot DFlash drafting
 void common_speculative_draft_batch(

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -189,15 +189,11 @@ bool llama_memory_recurrent::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos
                 if (rollback >= 1 && rollback <= (llama_pos) n_rs_seq) {
                     set_rs_idx(seq_id, (uint32_t) rollback);
                     cell.pos = p0 - 1;
-                    return true;
                 }
-                return false;
             }
             // invalidate tails which will be cleared
             if (p0 <= cell.pos && cell.pos < p1) {
-                if (p0 == 0) {
-                    tail_id = -1;
-                }
+                tail_id = -1;
             }
         }
     } else {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2704,7 +2704,9 @@ private:
                 } else {
                     const llama_tokens & cached_text_tokens = slot.prompt.tokens.get_text_tokens();
                     const auto & params_spec = slot.task->params.speculative;
-                    draft = common_speculative_draft(slot.get_spec(), params_spec, cached_text_tokens, slot.sampled);
+                    // Pass actual position (accounts for image tokens in M-RoPE) instead of text token count.
+                    const llama_pos n_past = slot.prompt.tokens.pos_next();
+                    draft = common_speculative_draft(slot.get_spec(), params_spec, cached_text_tokens, slot.sampled, nullptr, n_past);
                 }
 
                 if (draft.size() > (size_t) n_draft_max) {
@@ -3777,7 +3779,7 @@ private:
                             llama_clear_tree_parent_ids(ctx_tgt);
                             auto * mem = llama_get_memory(ctx_tgt);
                             llama_memory_seq_rm(mem, seq_backup, -1, -1);
-                            llama_memory_seq_rm(mem, slot.id, slot.prompt.n_tokens(), -1);
+                            llama_memory_seq_rm(mem, slot.id, slot.prompt.tokens.pos_next(), -1);
                         } else {
                             llama_clear_tree_parent_ids(ctx_tgt);
                             llama_dflash_rollback(ctx_tgt, slot.id, seq_backup, slot.n_tokens_before_draft, (int) ids.size());
@@ -3787,7 +3789,7 @@ private:
 
                         if (all_accepted) {
                             llama_memory_seq_rm(mem, seq_backup, -1, -1);
-                            llama_memory_seq_rm(mem, slot.id, slot.prompt.n_tokens(), -1);
+                            llama_memory_seq_rm(mem, slot.id, slot.prompt.tokens.pos_next(), -1);
                         } else {
                             const int n_past_before = slot.n_tokens_before_draft;
 
@@ -3811,7 +3813,7 @@ private:
                     slot.has_draft_backup = false;
                     slot.seq_id_backup = -1;
                 } else {
-                    llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, slot.prompt.n_tokens(), -1);
+                    llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, slot.prompt.tokens.pos_next(), -1);
                 }
 
                 common_speculative_rollback_dft(slot.get_spec(), slot.id, slot.prompt.n_tokens(), (uint16_t)(ids.size() - 1));


### PR DESCRIPTION
With vision models, image tokens contribute more positions than tokens (spatial dimensions), causing off-by-one errors when clearing KV cache after speculative decoding.

- common_speculative_draft(): add n_past_override param so caller passes actual M-RoPE position instead of relying on prompt_tgt.size()
- server-context: pass slot.prompt.tokens.pos_next() to 3 KV cache clear calls and to common_speculative_draft()
- llama-memory-recurrent: fix seq_rm to always invalidate tail_id and remove early returns that could skip invalidation
