### PR TITLE
fattn: add batch size guard to fused MMA turbo dispatch (fix #63)

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -1539,7 +1539,8 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
         return true;
     }();
     const bool turbo_matched = K->type == V->type && turbo_kv;
-    if (turbo_mma_fused && turbo_matched && (Q->ne[0] == 128 || Q->ne[0] == 256) &&
+    if (turbo_mma_fused && turbo_matched && Q->ne[1] <= 4 &&
+        (Q->ne[0] == 128 || Q->ne[0] == 256) &&
         turing_mma_available(ggml_cuda_info().devices[ggml_cuda_get_device()].cc)) {
         cudaStream_t stream = ctx.stream();
         int device;


### PR DESCRIPTION
The fused turbo flash attention path forces nstages=0 (synchronous tile loading) because cp.async can't do ALU dequant. During prefill with large batches this causes ~15-20% degradation in prompt eval performance.

Add Q->ne[1] <= 4 guard to restrict the fused path to decode-sized batches (single-token decode and MTP verification up to spec-draft-n-max
+ 1). Large prefill batches now correctly fall through to the pipelined prefill path with nstages > 0.
