### PR TITLE
ggml-hip: CMakeLists: fix HIP build by excluding bsa_*.cu by default

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -61,6 +61,7 @@ file(GLOB   GGML_HEADERS_ROCM "../ggml-cuda/*.cuh")
 list(APPEND GGML_HEADERS_ROCM "../../include/ggml-cuda.h")
 
 file(GLOB   GGML_SOURCES_ROCM "../ggml-cuda/*.cu")
+list(FILTER GGML_SOURCES_ROCM EXCLUDE REGEX "../ggml-cuda/bsa_.*\\.cu$")
 file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-tile*.cu")
 list(APPEND GGML_SOURCES_ROCM ${SRCS})
 file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-mma*.cu")


### PR DESCRIPTION
## Overview

This fixes the following build errors, I was in the process of creating the [`buun-llama.cpp-hip`](https://aur.archlinux.org/packages/buun-llama.cpp-hip) package for Arch Linux.

```
.../ggml/src/ggml-cuda/bsa_launcher.cu:5:10: fatal error: 'cuda_bf16.h' file not found
    5 | #include <cuda_bf16.h>
      |          ^~~~~~~~~~~~~
1 error generated when compiling for gfx1030.

.../ggml/src/ggml-cuda/bsa_fwd_inst.cu:9:10: fatal error: 'flash_fwd_block_hdim128_bf16_sm80.cu' file not found
    9 | #include "flash_fwd_block_hdim128_bf16_sm80.cu"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated when compiling for gfx1030.
```

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
