### PR TITLE
server: fix spec decoding crash and silent SSM state corruption with …

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1116,8 +1116,28 @@ private:
         }
 
         // Double n_parallel only when actual speculative decoding is active
-        // (external draft model or MTP), not for phantom --spec-type draft without -md.
-        if (params_base.speculative.has_dft() || params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_DRAFT_MTP)) {
+        // (draft model, MTP or any model-free self-speculation), not for phantom
+        // --spec-type draft without -md.
+        // The model-free types (ngram-*/suffix/copyspec/recycle) also verify draft
+        // tokens through the target context, so on hybrid/recurrent targets they
+        // need the same backup sequence (seq_id = slot.id + n_parallel_user) for
+        // partial-accept rollback. Without it the context is created with
+        // n_seq_max == n_parallel_user and llama_memory_recurrent::seq_cp() silently
+        // no-ops on the out-of-range backup seq — the rollback then wipes the
+        // recurrent state instead of restoring it (silent context corruption).
+        const bool has_model_free_spec =
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_NGRAM_SIMPLE)  ||
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K)   ||
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_NGRAM_MAP_K4V) ||
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_NGRAM_MOD)     ||
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_NGRAM_CACHE)   ||
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_SUFFIX)        ||
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_COPYSPEC)      ||
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_RECYCLE);
+
+        if (params_base.speculative.has_dft() ||
+            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_DRAFT_MTP) ||
+            has_model_free_spec) {
             params_base.n_parallel = n_parallel_user * 2;
             n_seq_max_full = params_base.n_parallel;
             recurrent_expanded = false;
@@ -1408,6 +1428,25 @@ private:
             };
 
             slot.reset();
+        }
+
+        // safety net: hybrid/recurrent partial-accept rollback requires one backup
+        // sequence per user slot. If a (future) speculative type slipped past the
+        // n_parallel doubling above, refuse to speculate instead of corrupting the
+        // recurrent state on the first partially-accepted draft.
+        if (needs_reeval && ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_RS &&
+            llama_n_seq_max(ctx_tgt) < (uint32_t) (2 * n_parallel_user)) {
+            bool any_spec = spec != nullptr;
+            for (auto & slot : slots) {
+                any_spec = any_spec || slot.can_speculate();
+                slot.spec.reset();
+                slot.spec_shared = nullptr;
+            }
+            spec.reset();
+            if (any_spec) {
+                SRV_ERR("speculative decoding disabled: hybrid/recurrent rollback needs n_seq_max >= %d, context has %u\n",
+                        2 * n_parallel_user, llama_n_seq_max(ctx_tgt));
+            }
         }
 
         {
@@ -3003,7 +3042,14 @@ private:
                 common_batch_add(batch, slot.sampled, slot.prompt.tokens.pos_next(), { slot.id }, true);
                 slot.prompt.tokens.push_back(slot.sampled);
 
-                if (slot.task->params.speculative.n_min > (int) draft.size()) {
+                // an empty draft (e.g. ngram-mod with no index match) must take the
+                // no-speculation path: the else-branch would leave spec_draft empty while
+                // spec_i_batch holds one index, so the accept loop (gated on
+                // !spec_draft.empty()) never consumes it and never samples a token for
+                // this cycle. the stale index then leaks into the next cycle's
+                // spec_i_batch, breaking the idxs.size() == draft.size() + 1 invariant
+                // and re-decoding slot.sampled every cycle (silent context corruption).
+                if (draft.empty() || slot.task->params.speculative.n_min > (int) draft.size()) {
                     SLT_DBG(slot, "ignoring small draft: %d < %d\n", (int) draft.size(), slot.task->params.speculative.n_min);
                     slot.i_batch = slot.spec_i_batch[0];
                     slot.spec_draft.clear();
@@ -4057,6 +4103,29 @@ private:
 
                 // save the original draft size
                 const size_t n_draft = slot.spec_draft.size();
+
+                // defensive: never feed a desynced spec state into
+                // common_sampler_sample_and_accept_n (it asserts on
+                // idxs.size() == draft.size() + 1). the batch build site always appends
+                // the current cycle's (n_draft + 1) contiguous indices last, so any
+                // excess can only be a stale prefix leaked from an earlier cycle.
+                if (slot.spec_i_batch.size() != n_draft + 1) {
+                    SLT_WRN(slot, "spec state desync (spec_i_batch = %zu, spec_draft = %zu) - recovering\n",
+                            slot.spec_i_batch.size(), n_draft);
+
+                    if (slot.spec_i_batch.size() > n_draft + 1) {
+                        // drop the stale prefix, keep the current cycle's indices
+                        slot.spec_i_batch.erase(slot.spec_i_batch.begin(), slot.spec_i_batch.end() - (n_draft + 1));
+                    } else {
+                        // should be unreachable: verify only as many draft tokens as
+                        // there are logit indices (n_draft keeps the original size so
+                        // the prompt rollback below stays consistent)
+                        slot.spec_draft.resize(slot.spec_i_batch.empty() ? 0 : slot.spec_i_batch.size() - 1);
+                        if (slot.spec_i_batch.empty()) {
+                            slot.spec_i_batch.push_back(batch.n_tokens > 0 ? batch.n_tokens - 1 : 0);
+                        }
+                    }
+                }
 
                 // the accepted tokens from the speculation
                 const auto ids = common_sampler_sample_and_accept_n(slot.smpl.get(), ctx_tgt, slot.spec_i_batch, slot.spec_draft);


### PR DESCRIPTION

## Summary

Running `llama-server` with any model-free `--spec-type` (e.g. `ngram-mod`) on a hybrid SSM+attention model (Qwen3.6-27B, arch `qwen35`) reliably crashes within a few hundred generated tokens:

```
common/sampling.cpp:635: GGML_ASSERT(idxs.size() == draft.size() + 1 && "idxs.size() must be draft.size() + 1") failed
```

Investigating the assert exposed a second, worse bug underneath it: **silent SSM state corruption** on partial-accept rollback with model-free spec types.

## Root cause

**Bug 1 — orphan indices from empty drafts.** With `--spec-type ngram-mod`, an empty draft (no index match) passes the `n_min > draft.size()` check (`0 > 0` = false) and enters the speculative path: `spec_i_batch` gains one index that the accept loop (gated on `!spec_draft.empty()`) never consumes. The orphan index accumulates every cycle — no new token is sampled and the same `slot.sampled` is re-decoded and pushed into the context — until the first real ngram match breaks the size invariant and fires the assert.

**Bug 2 — missing backup sequence for model-free types.** The `n_parallel` doubling that creates the rollback backup sequence only ran for draft-model/MTP types. With model-free types the context was created with `n_seq_max = 1`, so the recurrent-state backup `seq_cp` was a silent no-op (guard `seq_id_dst < size` in `llama-memory-recurrent.cpp`). On partial-accept rollback, `seq_rm` destroyed the SSM state and the "restore" restored nothing — all recurrent layers were left with only the ~reeval tokens. Output stays plausible but wrong, degrading over time (worst with prompt cache enabled).

## Fix

- Empty draft → non-speculative path
- Extend the `n_parallel` doubling to model-free spec types
- Defensive guard in the accept path + safety net in `load_model`

Single file (`tools/server/server-context.cpp`), 72 insertions, 3 deletions, commented.

## Validation (Qwen3.6-27B-MTP IQ3_XXS, RTX 5060 Ti 16GB, Windows)

- 34 generations of 1000+ tokens across turbo3/f16 KV with `ngram-mod`, `draft-mtp`, `draft-mtp,ngram-mod`, `dflash` — zero crashes (previously crashed on the first generation)
- **Greedy equivalence**: byte-exact output with spec on vs off (f16 KV), including runs with hundreds of partial-accept rollbacks — confirms the SSM corruption is fixed
- No perf regression: turbo3 tg @ d3072 = 27.3-28.2 t/s before and after
- Note (pre-existing, unrelated): with turbo3 KV there is a rare benign argmax swap between batch-verify (MMA+bulk-dequant) and single-token (VEC) kernels at tight logit margins — present on master without this patch

## Repro (before this patch)

```
llama-server -m Qwen3.6-27B-MTP-UD-IQ3_XXS.gguf -ngl 99 -fa on \
  -ctk turbo3 -ctv turbo3 --spec-type ngram-mod -c 32768
# request ~500+ tokens of code generation → assert within 1-2 requests
```


