### PR TITLE
Fix issue #71 and VBR performance degredation

### DIFF
--- a/ggml/src/ggml-cuda/vbr-transcode.cu
+++ b/ggml/src/ggml-cuda/vbr-transcode.cu
@@ -309,6 +309,19 @@ extern "C" void ggml_backend_cuda_vbr_fence_arm(ggml_backend_t backend) {
 }
 
 void ggml_cuda_vbr_fence_consume(int device, cudaStream_t stream) {
+    // Fast-path early-out: skip CUDA runtime calls entirely when no fences are armed on this device.
+    // At steady state (settled VBR, no degrades in flight) this eliminates ~4 driver transitions per token.
+    bool any_armed = false;
+    for (auto & f : g_vbr_fences) {
+        if (f.armed && f.device == device) {
+            any_armed = true;
+            break;
+        }
+    }
+    if (!any_armed) {
+        return;
+    }
+
     for (auto & f : g_vbr_fences) {
         if (!f.armed || f.device != device) {
             continue;

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1736,91 +1736,108 @@ llama_kv_cache::slot_info_vec_t llama_kv_cache::prepare(const std::vector<llama_
             }
             vbr_stash_dirty_ = false;
         }
-        // auto budgets track reality: re-derive from live free VRAM once per boundary
-        // (explicit budgets are a hard contract and never move)
-        if (!vbr_budget_explicit_) {
-            vbr_rederive_budget();
+        // -- Stability fast-path: skip per-batch bookkeeping when settled (avoids ~1ms/token) --
+        uint32_t used_now = 0;
+        for (uint32_t st = 0; st < n_stream; ++st) {
+            used_now += v_cells[st].get_used();
         }
-        // Degrades are one-way and lossy — the two honest recovery levers both live here, at the
-        // decode boundary, BEFORE the budget check:
-        //  - full-clear reset: the cache is EMPTY, so undoing every degrade is free and lossless;
-        //  - container promotion: occupancy dropped (seq_rm) far enough that a higher tier fits
-        //    with headroom — old rows keep their degraded quality (re-encoded recon, no
-        //    information restored), but FUTURE rows encode at the higher tier.
-        if (vbr_degrade_cursor_ > 0) {
-            uint32_t used = 0;
-            for (uint32_t st = 0; st < n_stream; ++st) {
-                used += v_cells[st].get_used();
+        // Stable when: budget fully explored, quiet for N boundaries, occupancy hasn't meaningfully moved.
+        static const uint32_t VBR_STABLE_QUICK = 10; // quiet-boundary threshold for fast path
+        static const int32_t  VBR_USED_DELTA   = 512; // occupancy delta below which we're stable
+        bool vbr_stable = (vbr_degrade_cursor_ >= std::min(vbr_degrade_order_.size(), vbr_degrade_limit_) &&
+                           vbr_quiet_boundaries_ >= VBR_STABLE_QUICK &&
+                           std::abs((int64_t)used_now - (int64_t)vbr_last_used_) < VBR_USED_DELTA);
+
+        if (!vbr_stable) {
+            // auto budgets track reality: throttle re-derive from live free VRAM — during steady
+            // decode occupancy barely changes, so querying every token is waste. Fire on the first
+            // boundary (lazy cuBLAS init), or when a degrades/promotes happen, or every 8th token.
+            if (!vbr_budget_explicit_) {
+                const bool budget_dirty = vbr_degrade_cursor_ > 0 && vbr_quiet_boundaries_ < VBR_STABLE_QUICK;
+                const bool budget_periodic = (vbr_boundary_count_ == 0 || vbr_boundary_count_ % 8 == 0);
+                if (budget_dirty || budget_periodic) {
+                    vbr_rederive_budget();
+                }
             }
-            if (used == 0) {
+            // Degrades are one-way and lossy — the two honest recovery levers both live here, at the
+            // decode boundary, BEFORE the budget check:
+            //  - full-clear reset: the cache is EMPTY, so undoing every degrade is free and lossless;
+            //  - container promotion: occupancy dropped (seq_rm) far enough that a higher tier fits
+            //    with headroom — old rows keep their degraded quality (re-encoded recon, no
+            //    information restored), but FUTURE rows encode at the higher tier.
+            if (vbr_degrade_cursor_ > 0 && used_now == 0) {
                 vbr_full_reset();
             }
-        }
-        const uint32_t wm_next = vbr_watermark_cells(n_tokens);
-        vbr_shrink_watermark(); // occupancy drops release phantom tail pages first
-        static const bool vbr_promote_on = [] {
-            const char * e = getenv("VBR_PROMOTE"); // kill switch for experiments; default ON
-            return e == nullptr || atoi(e) != 0;
-        }();
-        // promote pacing: ONE step per boundary, and only after a quiet window (no degrade in
-        // the last 4 boundaries). Promotes re-encode aged rows from degraded recon — error
-        // compounds per hop — so waves spread out and a clamp-driven degrade vetoes the
-        // immediate bounce-back. Boundary counting keeps the cooldown deterministic.
-        vbr_quiet_boundaries_++;
-        if (vbr_promote_on && vbr_degrade_cursor_ > 0 && vbr_quiet_boundaries_ >= 4) {
-            vbr_promote_next(wm_next);
-        }
-        // budget trigger: degrade while ANY pool exceeds its share. A step only shrinks the pool
-        // that owns its tensor, but the cursor is a global price order — advancing it while any
-        // pool is over budget is the simplest rule that terminates and preserves the price order.
-        while (vbr_over_budget(wm_next)) {
-            vbr_quiet_boundaries_ = 0; // degrade pressure this boundary — cool the promote path
-            if (!vbr_degrade_next(wm_next)) {
-                if (!vbr_budget_warned_) { // terminal state — one warning, not one per batch
-                    vbr_budget_warned_ = true;
-                    size_t projected_total = 0;
-                    for (const auto & p : vbr_pools_) {
-                        projected_total += p.vmm != nullptr ? vbr_vmm_projected_bytes(p, wm_next) : 0;
+            const uint32_t wm_next = vbr_watermark_cells(n_tokens);
+            vbr_shrink_watermark(); // occupancy drops release phantom tail pages first
+            static const bool vbr_promote_on = [] {
+                const char * e = getenv("VBR_PROMOTE"); // kill switch for experiments; default ON
+                return e == nullptr || atoi(e) != 0;
+            }();
+            // promote pacing: ONE step per boundary, and only after a quiet window (no degrade in
+            // the last 4 boundaries). Promotes re-encode aged rows from degraded recon — error
+            // compounds per hop — so waves spread out and a clamp-driven degrade vetoes the
+            // immediate bounce-back. Boundary counting keeps the cooldown deterministic.
+            vbr_quiet_boundaries_++;
+            if (vbr_promote_on && vbr_degrade_cursor_ > 0 && vbr_quiet_boundaries_ >= 4) {
+                vbr_promote_next(wm_next);
+            }
+            // budget trigger: degrade while ANY pool exceeds its share. A step only shrinks the pool
+            // that owns its tensor, but the cursor is a global price order — advancing it while any
+            // pool is over budget is the simplest rule that terminates and preserves the price order.
+            while (vbr_over_budget(wm_next)) {
+                vbr_quiet_boundaries_ = 0; // degrade pressure this boundary — cool the promote path
+                if (!vbr_degrade_next(wm_next)) {
+                    if (!vbr_budget_warned_) { // terminal state — one warning, not one per batch
+                        vbr_budget_warned_ = true;
+                        size_t projected_total = 0;
+                        for (const auto & p : vbr_pools_) {
+                            projected_total += p.vmm != nullptr ? vbr_vmm_projected_bytes(p, wm_next) : 0;
+                        }
+                        LLAMA_LOG_WARN("%s: VBR budget %.2f MiB exceeded with the degrade order %s (projected %.2f MiB at %u cells)\n",
+                                __func__, vbr_budget_bytes_/1024.0/1024.0,
+                                vbr_degrade_limit_ < vbr_degrade_order_.size() ? "clamped at the --vbr-floor" : "exhausted",
+                                projected_total/1024.0/1024.0, wm_next);
                     }
-                    LLAMA_LOG_WARN("%s: VBR budget %.2f MiB exceeded with the degrade order %s (projected %.2f MiB at %u cells)\n",
-                            __func__, vbr_budget_bytes_/1024.0/1024.0,
-                            vbr_degrade_limit_ < vbr_degrade_order_.size() ? "clamped at the --vbr-floor" : "exhausted",
-                            projected_total/1024.0/1024.0, wm_next);
+                    break;
                 }
-                break;
             }
-        }
-        // per-pool budget/occupancy trace for multi-GPU verification (visible with -v)
-        for (size_t pi = 0; pi < vbr_pools_.size(); ++pi) {
-            const auto & p = vbr_pools_[pi];
-            if (p.vmm == nullptr) {
-                continue;
+            // per-pool budget/occupancy trace for multi-GPU verification (visible with -v)
+            for (size_t pi = 0; pi < vbr_pools_.size(); ++pi) {
+                const auto & p = vbr_pools_[pi];
+                if (p.vmm == nullptr) {
+                    continue;
+                }
+                LLAMA_LOG_DEBUG("%s: VBR pool #%zu (device %d): projected %.2f / budget %.2f MiB (mapped %.2f) at %u cells\n",
+                        __func__, pi, p.device, vbr_vmm_projected_bytes(p, wm_next)/1024.0/1024.0,
+                        p.budget/1024.0/1024.0, p.be->vmm_pool_mapped(p.vmm)/1024.0/1024.0, wm_next);
             }
-            LLAMA_LOG_DEBUG("%s: VBR pool #%zu (device %d): projected %.2f / budget %.2f MiB (mapped %.2f) at %u cells\n",
-                    __func__, pi, p.device, vbr_vmm_projected_bytes(p, wm_next)/1024.0/1024.0,
-                    p.budget/1024.0/1024.0, p.be->vmm_pool_mapped(p.vmm)/1024.0/1024.0, wm_next);
-        }
-        // S5: the wave's transcodes/scrubs are queued on each pool's side stream — arm that
-        // device's fence so the next graph_compute GPU-waits on them; the host proceeds straight
-        // to graph build.
-        for (auto & p : vbr_pools_) {
-            if (p.wave_pending) {
-                p.be->fence_arm(p.backend);
-                p.wave_pending = false;
+            // S5: the wave's transcodes/scrubs are queued on each pool's side stream — arm that
+            // device's fence so the next graph_compute GPU-waits on them; the host proceeds straight
+            // to graph build.
+            for (auto & p : vbr_pools_) {
+                if (p.wave_pending) {
+                    p.be->fence_arm(p.backend);
+                    p.wave_pending = false;
+                }
             }
+            // Eager physical backing to the predicted watermark: map failures surface HERE, where no
+            // graphs exist and init_batch can fail RECOVERABLY (llama_decode returns an error; the
+            // server's decode-failure ladder — idle purge, batch halving — finally works under VBR
+            // instead of a process abort killing every client). Runs after the fence arm so an
+            // already-queued transcode wave stays fenced for the NEXT batch's graph either way.
+            // apply_ubatch's ensure_mapped remains as the mid-batch backstop for placements past
+            // the prediction.
+            if (!vbr_vmm_try_map(wm_next)) {
+                LLAMA_LOG_ERROR("%s: VBR VMM: physical map to %u cells failed (device memory exhausted) — "
+                        "failing this batch recoverably\n", __func__, wm_next);
+                return {};
+            }
+        } else {
+            // Fast path: settled, no work to do — just increment boundary counter and update last_used
+            vbr_quiet_boundaries_++;
         }
-        // Eager physical backing to the predicted watermark: map failures surface HERE, where no
-        // graphs exist and init_batch can fail RECOVERABLY (llama_decode returns an error; the
-        // server's decode-failure ladder — idle purge, batch halving — finally works under VBR
-        // instead of a process abort killing every client). Runs after the fence arm so an
-        // already-queued transcode wave stays fenced for the NEXT batch's graph either way.
-        // apply_ubatch's ensure_mapped remains as the mid-batch backstop for placements past
-        // the prediction.
-        if (!vbr_vmm_try_map(wm_next)) {
-            LLAMA_LOG_ERROR("%s: VBR VMM: physical map to %u cells failed (device memory exhausted) — "
-                    "failing this batch recoverably\n", __func__, wm_next);
-            return {};
-        }
+        vbr_last_used_ = used_now;
     }
 
     llama_kv_cache::slot_info_vec_t res;

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -341,6 +341,8 @@ private:
     uint64_t vbr_boundary_count_   = 0;
     size_t   vbr_growth_headroom_  = 0;
     bool     vbr_budget_explicit_  = false;
+    // Fast-path stability tracking: skip per-batch VBR bookkeeping when settled (avoids ~1ms/token)
+    uint32_t vbr_last_used_        = 0;   // observed cell count last prepare() pass
     void     vbr_rederive_budget();
     // sink-stash staleness guard: set when any cell below stash_rows is freed (its content can be
     // rewritten by another request; injecting the old snapshot would corrupt the new rows)

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1015,6 +1015,7 @@ private:
     // MTP↔mmproj GPU swap state
     bool mmproj_gpu_swap = false;
     bool mmproj_is_on_gpu = false;
+    bool mtp_was_active_before_swap = false;
 
     int64_t t_last_load_progress_ms = 0;
 
@@ -1089,6 +1090,7 @@ private:
         }
         spec.reset();
 
+        mtp_was_active_before_swap = ctx_dft != nullptr;
         if (ctx_dft) {
             ctx_dft.reset();
             params_base.speculative.draft.ctx_dft = nullptr;
@@ -1112,7 +1114,7 @@ private:
         mmproj_is_on_gpu = false;
         reload_mmproj(false);
 
-        if (ctx_dft) {
+        if (mtp_was_active_before_swap) {
             // Already had MTP before the swap — recreate it
             ctx_dft.reset(create_mtp_context());
             if (!ctx_dft) {


### PR DESCRIPTION
Two fixes:

    fix: MTP context not restored after mmproj-gpu-swap causes segfault on 2nd request
    
    Closes #71. Reported by @TheLeung who also identified the root cause and
    proposed this fix independently.
    
    When --mmproj-gpu-swap is enabled, swap_mtp_to_mmproj_gpu() destroys ctx_dft
    (the MTP draft context) to free VRAM for GPU-side image encoding. After the
    image is processed, swap_mmproj_to_mtp() was supposed to recreate it, but
    checked "if (ctx_dft)" — which is always nullptr since we just destroyed it in
    the previous step. The entire recreation block was skipped.
    
    After request #1 completes: ctx_dft is nullptr, all slots have slot.ctx_dft =
    nullptr, and spec/spec_shared are null. On request #2, prompt cache save/load
    attempts to access draft state through the null ctx_dft, causing either a
    GGML_ASSERT(backend) crash or segfault during "updating prompt cache".
    
    Fix: save whether MTP was active before destroying ctx_dft using
    mtp_was_active_before_swap, then check that flag instead of the already-null
    pointer in swap_mmproj_to_mtp(). This correctly recreates the MTP context,
    speculative state, and slot bindings after every swap cycle.
    
    The original implementation (commit 8e64d7a3a) always recreated MTP
    unconditionally; a later refactor added the if (ctx_dft) guard to handle the
    case where no MTP was configured, but forgot that ctx_dft is already destroyed
    by the time swap_mmproj_to_mtp() runs.


    VBR: stability fast-path eliminates per-token overhead when settled
    
    Three targeted fixes to reduce host-side VBR bookkeeping cost during
    steady-state decode.
    
    1) Stability fast-path in prepare() (llama-kv-cache.cpp/h):
       Wrap the entire per-batch VBR block (watermark calc, shrink, promote,
       budget loop, fence arm, VMM try_map) in a stability gate. When settled
       - degrade order exhausted, quiet for 10+ boundaries, occupancy delta
       < 512 cells - skip all bookkeeping and just increment the counter.
       Added vbr_last_used_ tracking field.
    
    2) Throttled budget re-derive (llama-kv-cache.cpp):
       Auto-budget path queries get_device_memory() on every token even when
       occupancy is stable. Throttle to once per 8th boundary, with exceptions
       for initial settle and active degrade/promote waves.
    
    3) Fence consume early-out (vbr-transcode.cu):
       ggml_cuda_vbr_fence_consume does a cheap armed-flag scan before the
       CUDA runtime loop. At steady state with no degrades in-flight, returns
       immediately without any driver transitions.