### PR TITLE
ui : copy missing static assets when HF prebuilt dist is incomplete

### DIFF
--- a/scripts/ui-assets.cmake
+++ b/scripts/ui-assets.cmake
@@ -250,7 +250,30 @@ function(hf_download version out_var out_resolved)
     endforeach()
 endfunction()
 
+# HF prebuilt dist.tar.gz can lag behind embed.cpp's required-asset list
+# (e.g. loading.html). Copy any missing root-level files from tools/ui/static/
+# so provisioned packages still embed successfully.
+function(ensure_static_fallbacks dist_dir)
+    if(NOT EXISTS "${dist_dir}/index.html")
+        return()
+    endif()
+    set(static_dir "${UI_SOURCE_DIR}/static")
+    if(NOT IS_DIRECTORY "${static_dir}")
+        return()
+    endif()
+    file(GLOB static_files LIST_DIRECTORIES false "${static_dir}/*")
+    foreach(src ${static_files})
+        get_filename_component(name "${src}" NAME)
+        if(NOT EXISTS "${dist_dir}/${name}")
+            message(STATUS "UI: copying missing static asset '${name}' from ${static_dir}")
+            file(COPY "${src}" DESTINATION "${dist_dir}")
+        endif()
+    endforeach()
+endfunction()
+
 function(emit_files dist_dir)
+    ensure_static_fallbacks("${dist_dir}")
+
     # If gzip is requested, compress every asset into a parallel _gzip/ tree
     # the structure stays the same; for ex: /abc/def --> /_gzip/abc/def
     # embed.cpp will check for _gzip and will pick it up


### PR DESCRIPTION
## Summary
- HF prebuilt UI packages (`ggml-org/llama-ui`) can omit assets that `llama-ui-embed` requires (e.g. `loading.html`).
- Without npm, the build always hits that path and fails with `missing required asset(s): loading.html`, even after a clean configure.
- Before gzip/embed, copy any missing root-level files from `tools/ui/static/` into the provisioned dist so the embed step succeeds.

## Test plan
- [x] `cmake --build build --target llama-ui-assets` with no npm installed
- [x] Confirm log shows `UI: copying missing static asset 'loading.html'`
- [x] Confirm `llama-ui-embed` writes `ui.cpp` / `ui.h` successfully
- [ ] Full `cmake --build build` continues past UI provisioning