### PR TITLE
Fix Windows MSVC compilation and shared library linking for TurboQuan…

### DIFF
--- a/ggml/include/ggml-turbo-meansub.h
+++ b/ggml/include/ggml-turbo-meansub.h
@@ -7,6 +7,7 @@
 // no TURBO_KMEAN_SUB / TURBO_VMEAN_SUB env override is set.
 
 #include <stdint.h>
+#include "ggml.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,11 +16,11 @@ extern "C" {
 // Record the active model identity (call once at load). arch = general.architecture string.
 // The match requires arch + n_layer + n_embd to agree, so a different model (e.g. the MoE
 // "qwen35moe", or any other geometry) never receives the wrong baked means.
-void ggml_turbo_meansub_set_model(const char * arch, int n_layer, int n_embd);
+GGML_API void ggml_turbo_meansub_set_model(const char * arch, int n_layer, int n_embd);
 
 // Dense baked mean slab [max_l * max_c] for the active model; kvsel: 0 = K, 1 = V.
 // Returns NULL when no baked table matches the active model. out_* may be NULL.
-const float * ggml_turbo_meansub_active(int kvsel, int * out_max_l, int * out_max_c, int * out_live);
+GGML_API const float * ggml_turbo_meansub_active(int kvsel, int * out_max_l, int * out_max_c, int * out_live);
 
 #ifdef __cplusplus
 }

--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -7,7 +7,9 @@
 #include <cctype>
 #include <string>
 #include <vector>
-
+#if defined(_WIN32) && !defined(strtok_r)
+#define strtok_r strtok_s
+#endif
 // Definition for the extern in turbo-quant-cuda.cuh. When true, the encode mean-sub tap is skipped
 // (VBR transcode re-encode: its input is already stored-domain V - mu_V).
 bool g_turbo_meansub_suppress = false;

--- a/ggml/src/ggml-turbo-meansub.cpp
+++ b/ggml/src/ggml-turbo-meansub.cpp
@@ -30,7 +30,7 @@ static const ggml_meansub_entry * g_active = NULL;
 static float * g_dense_k = NULL;
 static float * g_dense_v = NULL;
 
-void ggml_turbo_meansub_set_model(const char * arch, int n_layer, int n_embd) {
+GGML_API void ggml_turbo_meansub_set_model(const char * arch, int n_layer, int n_embd) {
     if (arch) {
         strncpy(g_arch, arch, sizeof(g_arch) - 1);
         g_arch[sizeof(g_arch) - 1] = 0;
@@ -77,7 +77,7 @@ static float * expand_dense(const ggml_meansub_entry * e, int kvsel) {
     return dense;
 }
 
-const float * ggml_turbo_meansub_active(int kvsel, int * out_max_l, int * out_max_c, int * out_live) {
+GGML_API const float * ggml_turbo_meansub_active(int kvsel, int * out_max_l, int * out_max_c, int * out_live) {
     if (!g_active) {
         return NULL;
     }

--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -1710,7 +1710,12 @@ static void multiple_choice_score(llama_context * ctx, const common_params & par
 
 // EXP-15d: defined in ggml-cuda/set-rows.cu. Weak so CPU-only builds link cleanly
 // (symbol resolves to nullptr → call is skipped below).
+#if defined(_MSC_VER)
+static inline void ggml_cuda_ragged_set_window_dummy(int) {}
+#define ggml_cuda_ragged_set_window ggml_cuda_ragged_set_window_dummy
+#else
 extern "C" __attribute__((weak)) void ggml_cuda_ragged_set_window(int window);
+#endif
 
 static void kl_divergence(llama_context * ctx, const common_params & params) {
     const llama_model * model = llama_get_model(ctx);


### PR DESCRIPTION
The following fixes have been applied to ensure cross-platform compatibility without affecting Linux/macOS or static builds:

1. **Fix `strtok_r` undefined identifier on MSVC (`ggml-cuda/set-rows.cu`)**:
   POSIX function `strtok_r` is not available in MSVC. Replaced it with the MSVC equivalent `strtok_s` guarded by `_MSC_VER`.

2. **Fix unsupported `__attribute__((weak))` on MSVC (`tools/perplexity/perplexity.cpp`)**:
   MSVC does not support the GCC/Clang weak symbol attribute, leading to syntax errors and DLL linking failures. Handled this by providing a dummy inline implementation under `_MSC_VER` to bypass the call cleanly on Windows, while preserving the original weak linkage fallback on other platforms.

3. **Fix `LNK2019` Unresolved External Symbol in DLL builds (`ggml-turbo-meansub`)**:
   When building `ggml` and `ggml-cuda` as separate DLLs, the symbols `ggml_turbo_meansub_set_model` and `ggml_turbo_meansub_active` were hidden by default on Windows. Added the `GGML_API` macro to their declarations and definitions to properly export them across library boundaries.
