### PR TITLE
fix(fit): correct n_ctx pricing when one KV side is pinned

### DIFF
--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -1133,7 +1133,7 @@ enum common_params_fit_status common_fit_params(
         // entry). A PINNED side (explicit q8_0/bf16 in a mixed config) keeps its real cost —
         // pricing it at the floor tier would over-advertise capacity for that half.
         auto movable = [](ggml_type t) {
-            return t == GGML_TYPE_F16 || ggml_is_turbo_kv_type(t);
+            return t == GGML_TYPE_F16 ;
         };
         if (movable(cparams->type_k)) {
             cparams->type_k = price_t;
@@ -1171,7 +1171,18 @@ enum common_params_fit_status common_fit_params(
         const ggml_type price_t  = common_vbr_floor_price_tier(cparams->vbr_min_bits);
         const double price_bpv = 8.0 * ggml_type_size(price_t) / ggml_blck_size(price_t);
         if (floor_bpv > price_bpv + 1e-9) {
-            uint32_t adjusted = (uint32_t) ((double) cparams->n_ctx * (price_bpv / floor_bpv));
+            // Only VBR-dynamic sides were priced at price_t (via movable()). Pinned
+            // sides kept their real cost. Compute the correct per-token KV ratio.
+            // movable() = (t == GGML_TYPE_F16) but that lambda isn't in scope here
+            auto is_vbr = [](ggml_type t) { return t == GGML_TYPE_F16; };
+            auto type_bpv = [](ggml_type t) { return 8.0 * ggml_type_size(t) / ggml_blck_size(t); };
+            double k_cost = is_vbr(type_k_entry) ? price_bpv : type_bpv(type_k_entry);
+            double v_cost = is_vbr(type_v_entry) ? price_bpv : type_bpv(type_v_entry);
+            double kv_at_price = k_cost + v_cost;
+            k_cost = is_vbr(type_k_entry) ? floor_bpv : type_bpv(type_k_entry);
+            v_cost = is_vbr(type_v_entry) ? floor_bpv : type_bpv(type_v_entry);
+            double kv_at_floor = k_cost + v_cost;
+            uint32_t adjusted = (uint32_t) ((double) cparams->n_ctx * (kv_at_price / kv_at_floor));
             adjusted = std::max<uint32_t>(256, adjusted - adjusted % 256);
             LOG_INF("%s: VBR dynamic: advertised n_ctx %" PRIu32 " -> %" PRIu32 " (literal floor %.4g "
                     "bits/value costs more than the %s pricing tier)\n",


### PR DESCRIPTION
The fit pass uses movable() to identify VBR-dynamic cache sides and price them at their degrade floor.  Previously movable() swapped ANY turbo type, including pinned types set explicitly by the user (e.g. -ctk turbo8, -ctk bf16), pricing them at turbo4 (~4 bpw) and overstating n_ctx.

This caused two cascading problems in mixed configs:

  1. The fit priced a pinned K=turbo8 at 4 bpw, overstating capacity → n_ctx 262 144, leading to OOM at runtime.

  2. Fix 1 (movable: only F16 is swappable) priced K at its real 8 bpw, but the post-fit adjustment still multiplied the entire n_ctx by price/floor = 4/6 = 0.667, treating      both halves as under-priced → n_ctx 155 904, wasting  ~37 MiB of VRAM.

Fix 1 — movable: only GGML_TYPE_F16 (the genuine VBR entry type) is swappable.  A pinned side keeps its real cost.

Fix 2 — n_ctx adjustment: compute a per-token KV cost ratio instead of the bpv ratio.  Only the VBR-dynamic side is adjusted by price/floor; a pinned side contributes its literal bits-per-value to both numerator and denominator, giving (K + V_price) / (K + V_floor).

Tested with -ctk turbo8 -ctv vbr --vbr-floor 6 on a 24 GiB RTX 3090 (Q4_K_XL Qwen3.6-27B):

  before both fixes:        n_ctx 262 144  (OOM at ~200 K)
  after Fix 1 only:         n_ctx 155 904  (under-estimated)
  after Fix 1 + Fix 2:      n_ctx 196 864  (correct, no OOM)

Full VRAM utilised, server stable at context limit.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Did this using Hermes+deepseek-v4-flash