### PR TITLE
fix(kv-cache): guard degrade trigger against budget below mapped

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -2431,7 +2431,9 @@ bool llama_kv_cache::vbr_over_budget(uint32_t wm_cells) const {
         if (p.vmm == nullptr) {
             continue;
         }
-        if (vbr_vmm_projected_bytes(p, wm_cells) > vbr_budget_eff(p)) {
+        const size_t mapped_now = p.be->vmm_pool_mapped(p.vmm);
+        const size_t safe_cap = std::max(vbr_budget_eff(p), mapped_now);
+        if (vbr_vmm_projected_bytes(p, wm_cells) > safe_cap) {
             return true;
         }
     }


### PR DESCRIPTION
When vbr_rederive_budget drops the effective budget below the physically mapped bytes (e.g. during tight VRAM conditions on a 24 GiB card), the degrade trigger vbr_budget_eff() alone causes a transcoding wave (f16 to turbo8) whose GPU-side stream reads from currently mapped pages. A budget below mapped tricks the degrade loop into reading unmapped VA, producing an illegal memory access CUDA error and killing the server.

Fix: clamp the over-budget comparison to max(budget_eff, mapped_now) so the trigger never fires when the budget drops below physically mapped memory. The transcode kernel always reads from valid pages.

Also tested with -ctk turbo8 -ctv vbr --vbr-floor 6 (the hardest case: K pinned at 8 bpw, V floor 6 bpw, 24 GiB RTX 3090). Before: CUDA illegal access at 93K tokens. After: 192K tokens stable, server alive.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Did this using Hermes+deepseek-v4-flash
