### PR TITLE
`llama-kv-cache: fix MSVC build error due to unsupported __int128 keyword`

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -4572,7 +4572,11 @@ bool llama_kv_cache::vbr_service_demands(const std::vector<llama_vram_peer_claim
         // with its own grants, decrements and pending. Non-iSWA: sibling is null and the
         // whole target is ours.
         // (our_offer + sib_offer > 0 guaranteed by the continue above)
+#ifdef _MSC_VER
+        const uint64_t own_target = (uint64_t) ((double) target * our_offer / (our_offer + sib_offer));
+#else
         const uint64_t own_target = (uint64_t) ((__int128) target * our_offer / (our_offer + sib_offer));
+#endif
         size_t freed_own = vbr_execute_shed(c, own_target, wm_next);
         grants_changed = grants_changed || freed_own > 0;
         if (vbr_ledger_sibling_ != nullptr && freed_own < target) {


### PR DESCRIPTION
## Overview

This PR addresses a compilation failure on MSVC targets (e.g., Windows x64 with MSVC 2022) when building `llama-kv-cache.cpp`. 

The error occurs because MSVC does not natively support the `__int128` type:
```text
llama-kv-cache.cpp(4575): error C4235: nonstandard extension used: '__int128' keyword not supported on this architecture
```

To resolve this, an `#ifdef _MSC_VER` guard is introduced around the ratio calculation (`own_target`). On MSVC, the calculation is handled using `double` precision, which is safe against integer overflow for realistic VRAM boundaries and maintains high numeric precision. Non-MSVC compilers (GCC and Clang) will continue using the existing high-precision `__int128` path.

## Additional information

The math in question scales a target value by a ratio of two offer footprints:
`target * our_offer / (our_offer + sib_offer)`

Since the physical capacity values fall well within the 53-bit precision range of a double-precision float (`~9e15`), performing this intermediate multiplication and division in `double` is robust and yields results that align with the integer code path.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

