### PR TITLE
fit: count MTP nextn layers in n_layer for VRAM estimation

### DIFF
--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -208,7 +208,7 @@ static std::vector<llama_device_memory_data> common_get_device_memory_data_impl(
         }
     }
 
-    hp_ngl         = llama_model_n_layer(model);
+    hp_ngl         = llama_model_n_layer(model) + llama_model_n_layer_nextn(model);
     hp_n_ctx_train = llama_model_n_ctx_train(model);
     hp_n_expert    = llama_model_n_expert(model);
 


### PR DESCRIPTION
When estimating device memory for models with multi-token prediction (MTP) layers, `hp_ngl` was only counting the base decoder layers via `llama_model_n_layer()`, omitting the `llama_model_n_layer_nextn()` heads.

This causes `llama-fit-params` to undercount total layers and give optimistic VRAM numbers for MTP models (e.g. Qwen3.6-MTP where nextn adds layers on top of the backbone).

One-line fix: add `llama_model_n_layer_nextn(model)` to the layer count, consistent with how `speculative.cpp` already treats MTP layers.