### PR TITLE
server: fix MTP draft dispatch for slots with id > 0 (parallel > 1)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -15638,6 +15638,21 @@ private:
                         llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), slot.id,
                                 llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id) + 1, -1);
                     }
+                } else if (!slot.spec && spec &&
+                           params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_DRAFT_MTP)) {
+                    // shared multi-seq MTP spec: arm this slot's own per-seq draft params.
+                    // the single-seq common_speculative_draft(spec, ...) wrapper below
+                    // always writes dparams[0], so slot.id > 0 would draft with stale
+                    // seq-0 state and produce garbage drafts (~random acceptance).
+                    const llama_tokens & cached_text_tokens = slot.prompt.tokens.get_text_tokens();
+                    auto & dp = common_speculative_get_draft_params(spec.get(), slot.id);
+                    dp.drafting = true;
+                    dp.n_max    = n_draft_max;
+                    dp.n_past   = slot.prompt.tokens.pos_next();
+                    dp.id_last  = slot.sampled;
+                    dp.prompt   = &cached_text_tokens;
+                    dp.result   = &draft;
+                    common_speculative_draft(spec.get());
                 } else {
                     const llama_tokens & cached_text_tokens = slot.prompt.tokens.get_text_tokens();
                     const auto & params_spec = slot.task->params.speculative;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -4572,7 +4572,12 @@ private:
         // Auto-fit mutates the target's llama_context_params, not params_base.  Reuse the
         // realized target width here; otherwise n_ctx=0 expands the MTP cache to n_ctx_train even
         // when the fitted target is much smaller.
-        cparams.n_ctx         = llama_n_ctx_seq(ctx_tgt);
+        // Honor an explicit --ctx-size-draft (params_base.speculative.draft.n_ctx) so the MTP
+        // draft cache can span more than one target slot's width (e.g. -c 524288 -cd 524288
+        // with --parallel 2) instead of silently capping at n_ctx_seq = target/n_parallel
+        // and failing llama_decode(ctx_dft) past that limit.
+        const int32_t spec_draft_n_ctx = params_base.speculative.draft.n_ctx;
+        cparams.n_ctx         = spec_draft_n_ctx > 0 ? spec_draft_n_ctx : llama_n_ctx_seq(ctx_tgt);
         cparams.ctx_type      = LLAMA_CONTEXT_TYPE_MTP;
         cparams.type_k        = params_base.speculative.draft.cache_type_k;
         cparams.type_v        = params_base.speculative.draft.cache_type_v;


### PR DESCRIPTION
# [Bug] MTP speculative decoding: draft acceptance collapses to ~0% on slot id > 0 with `--parallel N` — MTP branch dispatches per-slot drafts through the single-seq wrapper that hard-codes `dparams[0]`

## TL;DR

With `--parallel 2 --spec-type draft-mtp`, only slot 0 gets MTP acceleration. Slot 1's draft acceptance sits at **~2.7%** (essentially the random-guess baseline), so its generation gets no meaningful speedup — **even when slot 1 is exercised in complete isolation** (fresh restart, single client, slot 0 never touched).

**Root cause:** in `tools/server/server-context.cpp`, the per-slot draft dispatch loop (inside `pre_decode()`) has no dedicated MTP branch. The MTP case falls into the generic `else`, which calls the single-sequence convenience wrapper `common_speculative_draft(common_speculative*, const common_params_speculative&, ...)`. That wrapper **unconditionally arms `spec->dparams[0]`**. For MTP the server uses **one shared spec instance** with `n_seq = n_parallel` and each slot's `seq_id = slot.id`, so for slot 1 the per-seq draft params (`dparams[1]`) are never armed — the MTP impl's `draft()` then sees stale/never-written state for seq 1 and produces garbage drafts.

**Fix:** ~15 lines — route MTP through the vector `common_speculative_draft(common_speculative*)` with per-seq arming, exactly as the upstream master and this fork's own DFlash/DSpark branches already do. Measured with identical flags: slot 1 acceptance **0.027 → 0.724**, ~37.5 t/s.

## Environment

- Fork: `spiritbuun/buun-llama-cpp`, HEAD `2174ad63b` (2026-08-27, `vbr: fix automatic multi-GPU prompt capture`)
- OS: Windows 11 LTSC x64
- Model: `Qwen3.8-27B` Cold-Fusion GAIN V1.1 NEO-MAX-MTP, **Q4_K_M** (GGUF with native MTP head, `nextn_predict_layers=1`)
- GPUs: 2× RTX 4090 24GB
- Relevant flags (approximate launch config):
  - `--parallel 2 --spec-type draft-mtp`
  - `--spec-draft-device CUDA0,CUDA1` (draft on both GPUs, all draft layers on GPU)
  - `--spec-draft-n-max 2`
  - `--split-mode layer` (dual-GPU layer split, all layers on GPU)
  - `--flash-attn on`, turbo KV cache types, large context

Full launch script available on request.

## Symptoms

Server log, two slots generating concurrently:

```
id 0 | task 4249 | draft acceptance = 0.53874 ( 3226 accepted / 5988 generated), mean len = 2.08
id 0 | task 8508 | draft acceptance = 0.81818 (  162 accepted /  198 generated), mean len = 2.64
id 1 | task 8712 | draft acceptance = 0.027    (   63 accepted / 2300 generated), mean len = 1.05   ← broken
```

Decisive characteristics — this is **deterministic per-slot**, not a concurrency race:

1. `--parallel 1`: everything is normal (acceptance ~70%+).
2. **Fresh server restart, single client, request with `"slot_id": 1` forced** (buun extension field, parsed at `server-context.cpp:20649`) — slot 0 never touched: **still 0.027** (63/2300).
3. Same request type on slot 0: 0.54–0.82.
4. Reproducible across restarts.

A 2.7% acceptance on a ~248k-token vocabulary is only ~7× the blind-guess baseline — the drafter is *running* (its tokens land in a real verify batch) but its per-sequence state is wrong.

(For completeness: an unrelated issue was fixed separately around this time — the repo-baked chat template degraded slot 0's draft quality until we switched to the froggeric template. That fix changed slot 0's acceptance from ~2% to ~70%, but **did not change slot 1 at all**. The two problems are independent.)

## Root cause analysis

### How the shared MTP spec is set up

The server creates one shared MTP spec for all slots (`server-context.cpp`, `create_mtp_context()` + slot init):

- MTP draft context is `ctx_dft` created via `create_mtp_context()` (`ctx_type = LLAMA_CONTEXT_TYPE_MTP`, shares `model_tgt`)
- one spec instance: `common_speculative_init(params_base.speculative, params_base.n_parallel)` → `n_seq = n_parallel`
- per slot: `slot.spec_shared = spec.get()`; `slot.get_spec()` returns this shared instance (no per-slot `slot.spec` for MTP)
- `seq_id` for slot N is `N` (i.e. `slot.id`)

The MTP impl's `draft(dparams_vec)` (`common/speculative.cpp`, `common_speculative_impl_mtp::draft()`) iterates `seq_id in 0..n_seq`, and for every `dparams[seq_id].drafting == true` it drafts from `dp.n_past` / `dp.id_last` / `pending_h[seq_id]` and writes into `*dp.result`. **Correct per-slot dispatch therefore requires arming `dparams[slot.id]` before each draft call.**

### Where it breaks

The per-slot draft dispatch in `pre_decode()` has three branches (fork lines ~15614–15661):

```cpp
llama_tokens draft;
if (batched_draft_attempted[slot.id] || !batched_drafts[slot.id].empty()) {
    draft = std::move(batched_drafts[slot.id]);
} else if (!slot.spec && spec &&
           (params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH) ||
            params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK))) {
    // shared multi-seq state (block-diffusion DFlash / DSpark):
    // arm this slot's per-seq draft params — the fork single-seq wrapper
    // below always drives drafter seq 0, which only matches slot 0
    const llama_tokens & cached_text_tokens = slot.prompt.tokens.get_text_tokens();
    auto & dp   = common_speculative_get_draft_params(spec.get(), slot.id);
    dp.drafting = true;
    dp.n_max    = n_draft_max;
    dp.n_past   = slot.prompt.tokens.pos_next();
    dp.id_last  = slot.sampled;
    dp.prompt   = &cached_text_tokens;
    dp.result   = &draft;
    common_speculative_draft(spec.get());          // vector version — CORRECT
    ...
} else if (!slot.spec && spec &&
           params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_DRAFT_MTP)) {
    // *** THIS BRANCH DID NOT EXIST BEFORE THE FIX — MTP fell through to the else ***
    ...
} else {
    // MTP fell HERE — WRONG:
    const llama_tokens & cached_text_tokens = slot.prompt.tokens.get_text_tokens();
    const auto & params_spec = slot.task->params.speculative;
    const llama_pos n_past = slot.prompt.tokens.pos_next();
    draft = common_speculative_draft(slot.get_spec(), params_spec, cached_text_tokens, slot.sampled, nullptr, n_past);
}
```

The `else` calls the **single-sequence wrapper** (`common/speculative.cpp`):

```cpp
llama_tokens common_speculative_draft(
        common_speculative              * spec,
        const common_params_speculative & params,
        const llama_tokens              & prompt_tgt,
        llama_token                       id_last,
        std::vector<float>              * draft_log_probs,
        llama_pos                         n_past_override) {
    llama_tokens result;
    ...
    // set up dparams for seq 0
    auto & dp = spec->dparams[0];
    dp.drafting = true;
    dp.n_max    = params.n_max;
    dp.n_past   = n_past_override >= 0 ? n_past_override : (llama_pos)prompt_tgt.size();
    dp.id_last  = id_last;
    dp.prompt   = &prompt_tgt;
    dp.result   = &result;
    ...
    for (auto & impl : spec->impls) {
        impl->draft(spec->dparams);   // impl reads dparams[seq_id] for all seqs
    }
    ...
}
```

**`auto & dp = spec->dparams[0]` — hard-coded seq 0.**

So for slot 1 going through this path:

- `dparams[0]` gets armed **with slot 1's data, indexed under seq 0**;
- the MTP impl sees `dparams[0].drafting == true`, so it drafts **seq 0** (which in the isolated test has no real token stream), writing its tokens into the wrapper's local `result` → returned to slot 1 as "the draft" — but every token is produced from seq 0's stale KV/hidden state;
- **`dparams[1]` is never armed** — `pending_h[1]` / seq-1 draft KV never get refreshed by a proper draft cycle;
- every drafted token attributed to slot 1 is effectively random → acceptance ≈ baseline.

The DFlash branch's own comment documents this exact trap:

> "the fork single-seq wrapper below always drives drafter seq 0, which only matches slot 0"

The MTP branch simply wasn't given the same treatment.

### Why the symptoms match perfectly

- `-np 1`: `n_seq = 1`, so seq 0 = slot 0 = the only slot → the wrapper's hard-coded index happens to be right. Works.
- `-np 2`, forced single client on slot 1 (isolated): the wrapper writes `dparams[0]` for slot 1's draft, so the drafter burns compute on seq 0 while seq 1 (slot 1's real id) stays unarmed. Slot 1 shows ~random acceptance **in isolation**. Exactly what was observed.
- Concurrent run: slot 1's misrouted dispatch always targets `dparams[0]`, so its drafts are produced from seq 0's state; slot 0 still gets healthy acceptance because its own dispatch is correctly indexed. (This concurrent-interaction detail is inferred from the code path; the isolated single-slot reproduction is the authoritative one.)

## Upstream reference (correct pattern)

Official llama.cpp master, `tools/server/server-context.cpp` (~L2972–3019), arms per-seq params for *all* spec types including MTP, then calls the vector wrapper once:

```cpp
if (spec) {
    common_speculative_get_draft_params(spec.get(), slot.id).drafting = false;
    ...
    if (n_draft_max > 0) {
        ...
        common_speculative_get_draft_params(spec.get(), slot.id) = {
            /* .drafting = */ true,
            /* .n_max    = */ n_draft_max,
            /* .n_past   = */ slot.prompt.n_tokens(),
            /* .id_last  = */ slot.sampled,
            /* .prompt   = */ &slot.spec_prompt,
            /* .result   = */ &slot.spec_draft,
        };
        drafting.push_back(&slot);
    }
}
...
if (!drafting.empty()) {
    queue_tasks.yield_to_queue([&]() {
        common_speculative_draft(spec.get());     // vector version, per-seq dparams
    });
}
```

So this is a fork-local regression in the rewritten dispatch loop, not an upstream bug.

## Proposed fix

Add a dedicated MTP branch in the same dispatch loop in `server-context.cpp` (right before the final `else`):

```diff
                     // the fork single-seq wrapper below always drives drafter seq 0,
                     // which only matches slot 0
                     ...
                     if (ctx_dft) {
                         llama_memory_seq_rm(llama_get_memory(ctx_dft.get()), slot.id,
                                 llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id) + 1, -1);
                     }
+                } else if (!slot.spec && spec &&
+                           params_base.speculative.has_type(COMMON_SPECULATIVE_TYPE_DRAFT_MTP)) {
+                    // shared multi-seq MTP spec: arm THIS slot's own per-seq draft params.
+                    // the single-seq common_speculative_draft(spec, ...) wrapper below
+                    // always writes dparams[0], so slot.id > 0 would draft with stale
+                    // seq-0 state and produce garbage drafts (~random acceptance).
+                    const llama_tokens & cached_text_tokens = slot.prompt.tokens.get_text_tokens();
+                    auto & dp = common_speculative_get_draft_params(spec.get(), slot.id);
+                    dp.drafting = true;
+                    dp.n_max    = n_draft_max;
+                    dp.n_past   = slot.prompt.tokens.pos_next();
+                    dp.id_last  = slot.sampled;
+                    dp.prompt   = &cached_text_tokens;
+                    dp.result   = &draft;
+                    common_speculative_draft(spec.get());
                 } else {
                     const llama_tokens & cached_text_tokens = slot.prompt.tokens.get_text_tokens();
                     const auto & params_spec = slot.task->params.speculative;
                     const llama_pos n_past = slot.prompt.tokens.pos_next();
                     draft = common_speculative_draft(slot.get_spec(), params_spec, cached_text_tokens, slot.sampled, nullptr, n_past);
                 }
```

Notes:
- Reuses the existing vector wrapper `common_speculative_draft(common_speculative*)`, which already handles per-seq `drafting` flags, `dp.n_max` truncation, `impl_last[seq_id]` bookkeeping, and the CopySpec extension loop — the same contract the DFlash/DSpark branches rely on.
- No changes needed in the MTP impl itself; its `draft()` already iterates all `n_seq` sequences correctly, and it already trims its own stale draft-region KV at the start of `draft()` (`llama_memory_seq_rm(..., dp.n_past, -1)`), so no extra post-draft trim was needed in testing.
- The single-seq wrapper remains available for genuinely single-seq specs (n_seq == 1), where it is correct.

The diff above is exactly the patch that was compiled and verified (backup of the pre-patch file retained locally).

## Verification (identical flags, only the patch changed)

| | before | after |
|---|---|---|
| slot 0 acceptance | 0.539 / 0.818 | unchanged (0.539 / 0.818) |
| slot 1 acceptance | **0.027** (63/2300, mean len 1.05) | **0.724** (710/980, mean len 2.45) |
| slot 1 speed | ≈ no acceleration | ~37.5 t/s, stable, matching slot 0 class |
| concurrent run (both slots) | slot 1 stuck at ~2.7% | both slots in the 50–80% band |

## Reproduction

1. Build from `2174ad63b` (or any commit with the current dispatch loop).
2. Launch: `--parallel 2 --spec-type draft-mtp --spec-draft-n-max 2` with any model that has `nextn_predict_layers >= 1` (e.g. Qwen3.8-27B GGUF with MTP).
3. Send a completion request pinned to slot 1 (buun's `slot_id` request field; upstream has no equivalent, so the same effect can be forced by saturating slot 0 with another client, or by patching the same 3-line guard):
   ```json
   POST /completion
   {"prompt": "...", "n_predict": 300, "stream": false, "slot_id": 1}
   ```
4. Observe the server log: `slot id 1 | draft acceptance ≈ 0.0x` while `slot id 0` requests sit in the 0.5–0.8 band.

Happy to provide the full startup script or log captures on request.
